### PR TITLE
[PULL REQUEST] SQL Tables for Controls

### DIFF
--- a/sql/create_objects.sql
+++ b/sql/create_objects.sql
@@ -19,6 +19,28 @@ GO
 CREATE SCHEMA [inputs]
 GO
 
+CREATE TABLE [inputs].[controls_census_tract] (
+    [run_id] INT NOT NULL,
+    [year] INT NOT NULL,
+    [census_tract]  NVARCHAR(11) NOT NULL,
+    [metric] NVARCHAR(100) NOT NULL,
+    [value] FLOAT NOT NULL, 
+    INDEX [ccsi_inputs_controls_census_tract] CLUSTERED COLUMNSTORE,
+    CONSTRAINT [ixuq_inputs_controls_census_tract] UNIQUE ([run_id], [year], [census_tract], [metric]) WITH (DATA_COMPRESSION = PAGE),
+    CONSTRAINT [fk_inputs_controls_census_tract_run_id] FOREIGN KEY ([run_id]) REFERENCES [metadata].[run] ([run_id])
+)
+
+CREATE TABLE [inputs].[controls_city] (
+    [run_id] INT NOT NULL,
+    [year] INT NOT NULL,
+    [city]  NVARCHAR(15) NOT NULL,
+    [metric] NVARCHAR(100) NOT NULL,
+    [value] FLOAT NOT NULL, 
+    INDEX [ccsi_inputs_controls_city] CLUSTERED COLUMNSTORE,
+    CONSTRAINT [ixuq_inputs_controls_city] UNIQUE ([run_id], [year], [city], [metric]) WITH (DATA_COMPRESSION = PAGE),
+    CONSTRAINT [fk_inputs_controls_city_run_id] FOREIGN KEY ([run_id]) REFERENCES [metadata].[run] ([run_id])
+)
+
 CREATE TABLE [inputs].[mgra] (
     [run_id] INT NOT NULL,
     [mgra] INT NOT NULL,


### PR DESCRIPTION
**Describe this pull request. What changes are being made?**
Add SQL `[input]` tables to hold census tract and city level controls generated by the estimates program.

**What issues does this pull request address?**
closes #38
closes #42

**Additional context**
There are many options for these tables besides this current construct, but this seemed to be the easiest and most clear. The individual issues discuss this, and I am open to alternatives.
