### PR TITLE
[PULL REQUEST] Fix for `environment.yml` showing as a binary file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -40,11 +40,11 @@ dependencies:
   - xz=5.6.4=h4754444_1
   - zlib=1.2.13=h8cc25b3_1
   - pip:
-    - greenlet==3.1.1
-    - iteround==1.0.4
-    - pyaml==25.1.0
-    - pyodbc==5.2.0
-    - pyyaml==6.0.2
-    - sqlalchemy==2.0.38
-    - typing-extensions==4.12.2
-    - cerberus==1.3.7
+      - greenlet==3.1.1
+      - iteround==1.0.4
+      - pyaml==25.1.0
+      - pyodbc==5.2.0
+      - pyyaml==6.0.2
+      - sqlalchemy==2.0.38
+      - typing-extensions==4.12.2
+      - cerberus==1.3.7


### PR DESCRIPTION
**Describe this pull request. What changes are being made?**
Fix for `environment.yml` showing as a binary file. This was preventing GitHub from showing actual file diffs, which made it hard to see changes

**What issues does this pull request address?**
- Resolves #63

**Additional context**
I just changed the file encoding from `UTF-8` to `US-ASCII` and it seems to have been resolved. Also when resolving merge conflicts in my previous PR, GitHub decided to wipe the file so the contents have been restored. At least now you can confirm that GH diff is working again :) For that reason, please double check that the contents of the file are correct
