### PR TITLE
[PULL REQUEST] Replace iteround

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -43,7 +43,6 @@ dependencies:
       - cerberus==1.3.7
       - greenlet==3.1.1
       - git+https://github.com/SANDAG/ipfn@master
-      - iteround==1.0.4
       - polars==1.30.0
       - pyaml==25.1.0
       - pyodbc==5.2.0

--- a/python/hs_hh.py
+++ b/python/hs_hh.py
@@ -2,7 +2,6 @@
 # page for more details:
 # https://github.com/SANDAG/Estimates-Program/wiki/Housing-and-Households
 
-import iteround
 import pandas as pd
 import sqlalchemy as sql
 
@@ -167,7 +166,8 @@ def _create_hs_hh(hs_hh_inputs: dict[str, pd.DataFrame]) -> dict[str, pd.DataFra
         hh["value_hh"] *= city_rate / obs_rate
 
         # Integerize households preserving total
-        hh["value_hh"] = iteround.saferound(hh["value_hh"], places=0)
+        hh["value_hh"] *= round(hh["value_hh"].sum()) / hh["value_hh"].sum()
+        hh["value_hh"] = utils.integerize_1d(hh["value_hh"])
 
         # Reallocate households where households > housing stock or < 0
         # Add/remove households tracking total adjustment number

--- a/python/pop_type.py
+++ b/python/pop_type.py
@@ -1,7 +1,6 @@
 # Container for the Population by Type module. See the Estimates-Program wiki page for
 # more details: https://github.com/SANDAG/Estimates-Program/wiki/Population-by-Type
 
-import iteround
 import pandas as pd
 import sqlalchemy as sql
 
@@ -133,7 +132,7 @@ def _create_gq_outputs(gq_inputs: dict[str, pd.DataFrame]) -> dict[str, pd.DataF
         if city_control > 0:
             multiplier = city_control / city_gq["value"].sum()
             city_gq["value"] *= multiplier
-            city_gq["value"] = iteround.saferound(city_gq["value"], places=0)
+            city_gq["value"] = utils.integerize_1d(city_gq["value"])
         else:
             city_gq["value"] = 0
 
@@ -300,7 +299,7 @@ def _create_hhp_outputs(hhp_inputs: dict[str, pd.DataFrame]) -> dict[str, pd.Dat
         hhp["value_hhp"] *= multiplier
 
         # Integerize household population while preserving the total amount
-        hhp["value_hhp"] = iteround.saferound(hhp["value_hhp"], places=0)
+        hhp["value_hhp"] = utils.integerize_1d(hhp["value_hhp"])
 
         # Reallocate household population which contradicts the number of households.
         # See the _calculate_hhp_adjustment() function for exact situations
@@ -373,7 +372,7 @@ def _validate_hhp_outputs(hhp_outputs: dict[str, pd.DataFrame]) -> None:
 def _insert_hhp(
     hhp_inputs: dict[str, pd.DataFrame], hhp_outputs: dict[str, pd.DataFrame]
 ) -> None:
-    """Insert intput and output data related to household population"""
+    """Insert input and output data related to household population"""
 
     # Insert input and output data to database
     with utils.ESTIMATES_ENGINE.connect() as conn:


### PR DESCRIPTION
**Describe this pull request. What changes are being made?**
Replace the `iteround.saferound` function with the `integerize_1d` function.

**What issues does this pull request address?**
closes #92

**Additional context**
The `iteround.saferound` function would actually round non-integer sums to the closest integer value. This functionality was only used in the housing and households module as target vacancy rates were used to set households instead of integer control counts. As such, there is basic rounding done to mimic this functionality prior to passing to the `integerize_1d` function.