### PR TITLE
[PULL REQUEST] Special MGRAs Constraints

### DIFF
--- a/sql/create_objects.sql
+++ b/sql/create_objects.sql
@@ -78,7 +78,10 @@ CREATE TABLE [inputs].[special_mgras] (
     [sex] NVARCHAR(6) NULL,
     [min_age] INT NULL,
     [max_age] INT NULL,
-    [comment] NVARCHAR(max) NOT NULL
+    [comment] NVARCHAR(max) NOT NULL,
+    CONSTRAINT [pk_inputs_special_mgras] PRIMARY KEY ([id]),
+    CONSTRAINT [ixuq_inputs_special_mgras] UNIQUE ([mgra15], [start_year], [end_year], [pop_type], [sex], [min_age], [max_age]),
+    CONSTRAINT [chk_valid_sex_special_mgras] CHECK ([sex] IN ('Male', 'Female'))
 ) WITH (DATA_COMPRESSION = PAGE)
 
 INSERT INTO [inputs].[special_mgras] VALUES


### PR DESCRIPTION
**Describe this pull request. What changes are being made?**
Add constraints to `[inputs].[special_mgras]` table.

- Added primary key on `[id]`
- Added unique index on `[mgra15], [start_year], [end_year], [pop_type], [sex], [min_age], [max_age]`
- Added value constraint on `[sex]`

**What issues does this pull request address?**
closes #134

**Additional context**
Did not add value constraints on `[pop_type]` as these values may change or be added to in the future. Nowhere in the database currently controls these values. The choice to add a constraint to `[sex]` was made as this is a relatively small table so no performance impacts and `[sex]` will most likely never change in this project.

The current structure of the project does not allow for a foreign key constraint on `[mgra15]` to be added here as this table is created and populated prior to any data being inserted into `[inputs].[mgra]`. A future change, as discussed in #91, may allow for this foreign key constraint to be added.

Note this pull request is a blocker for #133.