### PR TITLE
[PULL REQUEST] Alternate methods to solve missing ASE seed data

### DIFF
--- a/python/ase.py
+++ b/python/ase.py
@@ -523,22 +523,11 @@ def _create_ase(
     post_ipf_data = []
     for pop_type in seed_mgras["pop_type"].unique():
 
-        # Filter the data to this population type and transform into a 2D array
+        # Filter the data to this population type
         pop_type_seed = (
             seed_mgras[seed_mgras["pop_type"] == pop_type]
             # Take only a subset of the original data for speed
             [["mgra", "age_group", "sex", "ethnicity", "value"]]
-            # Sort values to ensure a consistent ordering
-            .sort_values(by=["mgra", "age_group", "sex", "ethnicity"])
-            # Re-shape to 2D
-            .pivot(index="mgra", columns=["age_group", "sex", "ethnicity"])
-        )
-
-        # Get the row controls (aka MGRA population by type)
-        row_controls = (
-            ase_inputs["mgra_pop_type"]
-            .loc[lambda df: df["pop_type"] == pop_type][["mgra", "value"]]
-            .sort_values(by="mgra")
         )
 
         # Get the column controls (aka regional population by type and by ASE)
@@ -550,27 +539,58 @@ def _create_ase(
             .sort_values(by=["age_group", "sex", "ethnicity"])
         )
 
-        # Check seed data columns and column controls are aligned
-        # If there exists a column in the seed data with no non-zero values and a non-zero control
-        # Identify eligible rows in the seed data as those with non-zero values in adjacent columns
-        # Set the values in these rows to 1/number of eligible rows
-        for col_idx in range(pop_type_seed.shape[1]):
-            if pop_type_seed.iloc[:, col_idx].sum() == 0:
-                # Get the corresponding value in col_controls by index
-                if col_controls.iloc[col_idx]["value"] != 0:
-                    logger.warning(f"Zero seed column with non-zero control: {pop_type_seed.columns[col_idx]}")
-                    # Adjust seed data as described
-                    window = 1
-                    eligible_rows = pd.Series(False, index=pop_type_seed.index)
-                    while eligible_rows.sum() == 0:
-                        if col_idx - window >= 0:
-                            eligible_rows = eligible_rows | (pop_type_seed.iloc[:, col_idx-window] != 0)
-                        if col_idx + window < pop_type_seed.shape[1]:
-                            eligible_rows = eligible_rows | (pop_type_seed.iloc[:, col_idx+window] != 0)
-                        if eligible_rows.sum() > 0:
-                            pop_type_seed.iloc[eligible_rows, col_idx] = 1 / eligible_rows.sum()
-                        else:
-                            window +=1
+        # Double check that every non-zero control has at some non-zero data associated
+        # with it
+        check_df = (
+            pop_type_seed.groupby(utils.ASE)[["value"]]
+            .sum()
+            .join(
+                col_controls.set_index(utils.ASE),
+                how="inner",
+                lsuffix="_seed",
+                rsuffix="_ctrl",
+                validate="one_to_one",
+            )
+            .loc[lambda df: (df["value_ctrl"] > 0) & (df["value_seed"] == 0)]
+        )
+        if check_df.shape[0] > 0:
+            # In the case we run into this error, we make the assumption that the column
+            # controls are correct, so seed data needs to be adjusted. Furthermore, it
+            # is assumed that population tends to group primarily by ethnicity, rather
+            # than age or sex. Therefore, we find MGRAs that match pop type and
+            # ethnictiy, and seed with a tiny amount of the ASE category
+            check_df = check_df.reset_index(drop=False)
+            for row_number in range(0, check_df.shape[0]):
+                ASE_to_fix = check_df.iloc[row_number]
+
+                # Find which MGRAs match pop_type and ethnicity
+                valid_mgras = pop_type_seed.loc[
+                    lambda df: (df["ethnicity"] == ASE_to_fix["ethnicity"])
+                    & (df["value"] > 0)
+                ]["mgra"].unique()
+
+                # Give those MGRAs a small seed value for the ASE category
+                pop_type_seed.loc[
+                    (pop_type_seed["mgra"].isin(valid_mgras))
+                    & (pop_type_seed["age_group"] == ASE_to_fix["age_group"])
+                    & (pop_type_seed["sex"] == ASE_to_fix["sex"])
+                    & (pop_type_seed["ethnicity"] == ASE_to_fix["ethnicity"]),
+                    "value",
+                ] = (
+                    1 / ASE_to_fix["value_ctrl"]
+                )
+
+        # Re-shape to 2D for IPF
+        pop_type_seed = pop_type_seed.sort_values(
+            by=["mgra", "age_group", "sex", "ethnicity"]
+        ).pivot(index="mgra", columns=["age_group", "sex", "ethnicity"])
+
+        # Get the row controls (aka MGRA population by type)
+        row_controls = (
+            ase_inputs["mgra_pop_type"]
+            .loc[lambda df: df["pop_type"] == pop_type][["mgra", "value"]]
+            .sort_values(by="mgra")
+        )
 
         # Run IPF
         pop_type_post_ipf_data = utils.ipf(
@@ -989,8 +1009,7 @@ def _insert_ase(ase_outputs: dict[str, pd.DataFrame], debug: bool) -> None:
 
             # Then, bulk insert the CSV file into the production database
             with utils.ESTIMATES_ENGINE.connect() as con:
-                query = sql.text(
-                    f"""
+                query = sql.text(f"""
                         BULK INSERT [outputs].[ase]
                         FROM '{csv_temp_location.as_posix()}'
                         WITH (
@@ -1000,8 +1019,7 @@ def _insert_ase(ase_outputs: dict[str, pd.DataFrame], debug: bool) -> None:
                             ROWTERMINATOR = '0x0A',
                             CHECK_CONSTRAINTS
                         )
-                    """
-                )
+                    """)
                 con.execute(query)
                 con.commit()
 

--- a/python/ase.py
+++ b/python/ase.py
@@ -553,31 +553,40 @@ def _create_ase(
             )
             .loc[lambda df: (df["value_ctrl"] > 0) & (df["value_seed"] == 0)]
         )
+        # TODO: How we resolve the error
         if check_df.shape[0] > 0:
-            # In the case we run into this error, we make the assumption that the column
-            # controls are correct, so seed data needs to be adjusted. Furthermore, it
-            # is assumed that population tends to group primarily by ethnicity, rather
-            # than age or sex. Therefore, we find MGRAs that match pop type and
-            # ethnictiy, and seed with a tiny amount of the ASE category
             check_df = check_df.reset_index(drop=False)
             for row_number in range(0, check_df.shape[0]):
-                ASE_to_fix = check_df.iloc[row_number]
+                ase_to_fix = check_df.iloc[row_number]
 
-                # Find which MGRAs match pop_type and ethnicity
-                valid_mgras = pop_type_seed.loc[
-                    lambda df: (df["ethnicity"] == ASE_to_fix["ethnicity"])
-                    & (df["value"] > 0)
-                ]["mgra"].unique()
+                # Find historic tracts which have this ASE category
+                with utils.ESTIMATES_ENGINE.connect() as con:
+                    with open(
+                        utils.SQL_FOLDER / "ase/get_mgras_with_ase_pop.sql"
+                    ) as file:
+                        mgras_with_ase = utils.read_sql_query_fallback(
+                            # Lookback to the most recent decennial
+                            max_lookback=year - (year // 10 * 10),
+                            sql=sql.text(file.read()),
+                            con=con,
+                            params={
+                                "age_group": ase_to_fix["age_group"],
+                                "sex": ase_to_fix["sex"],
+                                "ethnicity": ase_to_fix["ethnicity"],
+                                "year": year,
+                                "series": utils.SERIES,
+                            },
+                        )
 
                 # Give those MGRAs a small seed value for the ASE category
                 pop_type_seed.loc[
-                    (pop_type_seed["mgra"].isin(valid_mgras))
-                    & (pop_type_seed["age_group"] == ASE_to_fix["age_group"])
-                    & (pop_type_seed["sex"] == ASE_to_fix["sex"])
-                    & (pop_type_seed["ethnicity"] == ASE_to_fix["ethnicity"]),
+                    (pop_type_seed["mgra"].isin(mgras_with_ase["mgra"]))
+                    & (pop_type_seed["age_group"] == ase_to_fix["age_group"])
+                    & (pop_type_seed["sex"] == ase_to_fix["sex"])
+                    & (pop_type_seed["ethnicity"] == ase_to_fix["ethnicity"]),
                     "value",
                 ] = (
-                    1 / ASE_to_fix["value_ctrl"]
+                    1 / ase_to_fix["value_ctrl"]
                 )
 
         # Re-shape to 2D for IPF

--- a/sql/ase/get_mgras_with_ase_pop.sql
+++ b/sql/ase/get_mgras_with_ase_pop.sql
@@ -1,0 +1,85 @@
+/*
+Find Census Tracts which have population matching the input year and age/sex/ethnicity
+category.
+*/
+
+-- Initialize parameters --------------------------------------------------------------
+DECLARE @age_group NVARCHAR(MAX) = :age_group;
+DECLARE @sex NVARCHAR(MAX) = :sex;
+DECLARE @ethnicity NVARCHAR(MAX) = :ethnicity;
+DECLARE @year INTEGER = :year;
+DECLARE @series INTEGER = :series;
+
+-- Send error message if no data exists -----------------------------------------------
+IF @year > 2011
+BEGIN
+SELECT 'ACS 5-Year Data does not exist' AS [msg]
+END
+
+-- Find tracts in the given year/ASE with population ----------------------------------
+ELSE
+BEGIN
+SELECT DISTINCT [mgra]
+FROM [demographic_warehouse].[dim].[mgra_xref]
+INNER JOIN [demographic_warehouse].[dim].[mgra]
+    ON [mgra_xref].[mgra_id] = [mgra].[mgra_id]
+WHERE [series] = @series
+    AND [xref_year] = @year
+    AND [tract] IN (
+        SELECT DISTINCT [tract]
+        FROM (
+            SELECT
+                [tract],
+                CASE
+                    WHEN [variables].[label] LIKE 'Estimate%Female%' THEN 'Female'
+                    WHEN [variables].[label] LIKE 'Estimate%Male%' THEN 'Male'
+                    ELSE NULL
+                END AS [sex],
+                -- Note: race categories are consistent with Estimates program and will be generated in IPF process
+                CASE
+                    WHEN [tables].[description] = 'SEX BY AGE (HISPANIC OR LATINO)' THEN 'Hispanic'
+                    WHEN [tables].[description] = 'SEX BY AGE (WHITE ALONE, NOT HISPANIC OR LATINO)' THEN 'Non-Hispanic, White'
+                    WHEN [tables].[description] = 'SEX BY AGE (BLACK OR AFRICAN AMERICAN ALONE)' THEN 'Non-Hispanic, Black'
+                    WHEN [tables].[description] = 'SEX BY AGE (AMERICAN INDIAN AND ALASKA NATIVE ALONE)' THEN 'Non-Hispanic, American Indian or Alaska Native'
+                    WHEN [tables].[description] = 'SEX BY AGE (ASIAN ALONE)' THEN 'Non-Hispanic, Asian'
+                    WHEN [tables].[description] = 'SEX BY AGE (NATIVE HAWAIIAN AND OTHER PACIFIC ISLANDER ALONE)' THEN 'Non-Hispanic, Hawaiian or Pacific Islander'
+                    WHEN [tables].[description] = 'SEX BY AGE (TWO OR MORE RACES)' THEN 'Non-Hispanic, Two or More Races'
+                ELSE NULL
+                END AS [ethnicity],
+                CASE
+                    WHEN [variables].[label] LIKE 'Estimate%Under 5%' THEN 'Under 5'
+                    WHEN [variables].[label] LIKE 'Estimate%5 to 9%' THEN '5 to 9'
+                    WHEN [variables].[label] LIKE 'Estimate%10 to 14%' THEN '10 to 14'
+                    WHEN [variables].[label] LIKE 'Estimate%15 to 17%' THEN '15 to 17'
+                    WHEN [variables].[label] LIKE 'Estimate%18 and 19%' THEN '18 and 19'
+                    WHEN [variables].[label] LIKE 'Estimate%20 to 24 years%' THEN '20 to 24'
+                    WHEN [variables].[label] LIKE 'Estimate%25 to 29%' THEN '25 to 29'
+                    WHEN [variables].[label] LIKE 'Estimate%30 to 34%' THEN '30 to 34'
+                    WHEN [variables].[label] LIKE 'Estimate%35 to 44%' THEN '35 to 44'
+                    WHEN [variables].[label] LIKE 'Estimate%45 to 54%' THEN '45 to 54'
+                    WHEN [variables].[label] LIKE 'Estimate%55 to 64%' THEN '55 to 64'
+                    WHEN [variables].[label] LIKE 'Estimate%65 to 74%' THEN '65 to 74'
+                    WHEN [variables].[label] LIKE 'Estimate%75 to 84%' THEN '75 to 84'
+                    WHEN [variables].[label] LIKE 'Estimate%85 years and over%' THEN '85 and Older'
+                    ELSE NULL
+                END AS [age_group],
+                [value]
+            FROM [acs].[detailed].[values]
+            LEFT JOIN [acs].[detailed].[tables]
+                ON [values].[table_id] = [tables].[table_id]
+            LEFT JOIN [acs].[detailed].[variables]
+                ON [values].[variable] = [variables].[variable]
+            AND [values].[table_id] = [variables].[table_id]
+            LEFT JOIN [acs].[detailed].[geography]
+                ON [values].[geography_id] = [geography].[geography_id]
+            WHERE
+                [tables].[name] IN ('B01001B', 'B01001C', 'B01001D', 'B01001E', 'B01001G', 'B01001H', 'B01001I')
+                AND [tables].[product] = '5Y'
+                AND [tables].[year] = @year
+        ) AS [tbl]
+        WHERE [age_group] = @age_group
+            AND [sex] = @sex
+            AND [ethnicity] = @ethnicity
+            AND [value] > 0
+    )
+END


### PR DESCRIPTION
### Describe this pull request. What changes are being made?
See discussion in #240 for additional background. Then, this PR tried two different ways to solve the missing 85+ F NHHPI HHP seed data:
1. (`[run_id]=200`) Find MGRAs with NHHPI HHP and add the 85+ F NHHPI HHP to those MGRAs. The logic being that the missing seed data is most likely to come from MGRAs that already have the same ethnicity (to see this methodology, you will have to revert the most recent commit in this PR)
2. (`[run_id]=201`)Use the most recent year of ACS which has 85+ F NHHPI HHP in it and find the CTs/MGRAs which have the pop. Add seed data to those MGRAs

### What issues does this pull request address?
See #240

### Additional context
This PR is not complete! The code as it is should function for all years, but it's not guaranteed due to the hardcoded nature of some things:
- The error message in the new SQL script is hard-coded for certain years
- The SQL script will fail due to mismatch of ten year (in the ACS) and five year (from Estimates Program) age groups. Since the error was 85+, this mismatch doesn't matter for #240