### PR TITLE
[PULL REQUEST] Regional Employment Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ direction TB
         year INT UK
         ownership_title NVARCHAR(50) UK
         industry_code NVARCHAR(5) UK
-        metric NVARCHAR(4) UK
         value INT
     }
 

--- a/python/employment.py
+++ b/python/employment.py
@@ -436,6 +436,17 @@ def _create_controls_outputs(
 
         # Aggregate to SANDAG employment categories
 
+        # Remove NAICS 99 and Private ownership 92
+        result_set = result_set.loc[
+            ~(
+                (result_set["industry_code"] == "99")
+                | (
+                    (result_set["ownership_title"] == "Private")
+                    & (result_set["industry_code"] == "92")
+                )
+            )
+        ]
+
         # Following NAICS codes include all ownership categories
         result_set.loc[
             result_set["industry_code"].isin(["61", "62", "71", "721", "722"]),
@@ -450,17 +461,6 @@ def _create_controls_outputs(
             ),
             "industry_code",
         ] = "GOV"
-
-        # Remove NAICS 99 and Private ownership 92
-        result_set = result_set.loc[
-            ~(
-                (result_set["industry_code"] == "99")
-                | (
-                    (result_set["ownership_title"] == "Private")
-                    & (result_set["industry_code"] == "92")
-                )
-            )
-        ]
 
         result_set = (
             result_set.groupby(

--- a/python/employment.py
+++ b/python/employment.py
@@ -1,5 +1,7 @@
-# Container for the Employment module. See the Estimates-Program wiki page for
-# more details: Wiki page TBD
+# Container for the Employment module. See the Estimates-Program wiki page for more details
+# https://github.com/SANDAG/Estimates-Program/wiki/Employment
+
+import functools
 
 import numpy as np
 import pandas as pd
@@ -30,14 +32,494 @@ def run_employment(year: int, debug: bool):
     Args:
         year: estimates year
     """
+    # Calculate regional jobs controls by SANDAG employment category
+    controls_inputs = _get_controls_inputs(year)
+    _validate_controls_inputs(controls_inputs)
 
+    controls_outputs = _create_controls_outputs(controls_inputs, year)
+    _validate_controls_outputs(controls_outputs)
+
+    _insert_controls(controls_outputs, debug)
+
+    # Calculate MGRA level jobs by SANDAG employment category
     jobs_inputs = _get_jobs_inputs(year)
     _validate_jobs_inputs(jobs_inputs)
 
     jobs_outputs = _create_jobs_output(jobs_inputs, year)
     _validate_jobs_outputs(jobs_outputs)
 
-    _insert_jobs(jobs_inputs, jobs_outputs, debug)
+    _insert_jobs(jobs_outputs, debug)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_controls_inputs(year: int) -> dict[str, pd.DataFrame]:
+    """Get inputs required to calculate regional jobs controls.
+
+    The inputs required to calculate regional jobs controls by SANDAG employment
+    category vary by year. For years prior to 2022, due to suppression in the
+    BLS QCEW data, a methodology is used to calculate regional controls that
+    requires multiple input datasets from the BLS QCEW and the confidential
+    California Employment Development Department (EDD) datasets. For years 2022
+    and later, the BLS QCEW data can be used directly to calculate regional controls.
+    """
+    # Initialize return dictionary
+    controls_inputs = {}
+
+    # Years prior to 2022 use methodology to account for BLS QCEW suppression
+    # And cannot use the BLS QCEW data directly
+    if year < 2022:
+        queries = {
+            "military": {
+                "server": utils.GIS_SERVER,
+                "query": "employment/get_military_employment.sql",
+                "params": {
+                    "run_id": utils.RUN_ID,
+                    "year": year,
+                    "series": utils.SERIES,
+                },
+            },
+            "region_edd": {
+                "server": utils.GIS_SERVER,
+                "query": "employment/get_region_edd.sql",
+                "params": {"year": year, "estimates_server": utils.ESTIMATES_SERVER},
+            },
+            "qcew_domain": {
+                "server": utils.ESTIMATES_SERVER,
+                "query": "employment/get_bls_qcew_domain.sql",
+                "params": {"year": year},
+            },
+            "qcew_supersector": {
+                "server": utils.ESTIMATES_SERVER,
+                "query": "employment/get_bls_qcew_supersector.sql",
+                "params": {"year": year},
+            },
+            "qcew_naics_sector": {
+                "server": utils.ESTIMATES_SERVER,
+                "query": "employment/get_bls_qcew_naics_sector.sql",
+                "params": {"year": year},
+            },
+            "qcew_naics3": {
+                "server": utils.ESTIMATES_SERVER,
+                "query": "employment/get_bls_qcew_naics3.sql",
+                "params": {"year": year},
+            },
+        }
+    # Years 2022 and later can use the BLS QCEW data directly
+    else:
+        queries = {
+            "military": {
+                "server": utils.GIS_SERVER,
+                "query": "employment/get_military_employment.sql",
+                "params": {
+                    "run_id": utils.RUN_ID,
+                    "year": year,
+                    "series": utils.SERIES,
+                },
+            },
+            "region_qcew": {
+                "server": utils.ESTIMATES_SERVER,
+                "query": "employment/get_region_qcew.sql",
+                "params": {"run_id": utils.RUN_ID, "year": year},
+            },
+        }
+
+    for key, value in queries.items():
+        if value["server"] == utils.ESTIMATES_SERVER:
+            with utils.ESTIMATES_ENGINE.connect() as con:
+                with open(utils.SQL_FOLDER / value["query"]) as file:
+                    controls_inputs[key] = utils.read_sql_query_fallback(
+                        sql=sql.text(file.read()),
+                        con=con,
+                        params=value["params"],
+                    )
+        elif value["server"] == utils.GIS_SERVER:
+            with utils.GIS_ENGINE.connect() as con:
+                with open(utils.SQL_FOLDER / value["query"]) as file:
+                    controls_inputs[key] = utils.read_sql_query_fallback(
+                        sql=sql.text(file.read()),
+                        con=con,
+                        params=value["params"],
+                    )
+
+    return controls_inputs
+
+
+def _validate_controls_inputs(controls_inputs: dict[str, pd.DataFrame]) -> None:
+    """Validate the regional jobs controls input data."""
+    datasets = {
+        "military": {
+            "table_name": "Military employment data",
+            "row_count": {"key_columns": {"mgra"}},
+            "negative": {},
+            "null": {},
+        },
+        "region_edd": {
+            "table_name": "Regional EDD data",
+            "row_count": {
+                "key_columns": {"ownership_title", ("naics3", "naics_sector")}
+            },
+            "negative": {},
+            "null": {"null_ok": {"naics3"}},  # NULLs are allowed in the NAICS3 field
+        },
+        "region_qcew": {
+            "table_name": "Regional BLS QCEW data",
+            # Row count validation not performed as the BLS QCEW data
+            # Contains only 23 of the 24 employment categories due to military
+            "row_count": None,
+            "negative": {},
+            "null": {},
+        },
+        "qcew_domain": {
+            "table_name": "BLS QCEW domain data",
+            "row_count": {"key_columns": {"ownership_title", "domain"}},
+            "negative": {},
+            "null": {},
+        },
+        "qcew_supersector": {
+            "table_name": "BLS QCEW supersector data",
+            "row_count": {"key_columns": {"ownership_title", "supersector"}},
+            "negative": {},
+            "null": {},
+        },
+        "qcew_naics_sector": {
+            "table_name": "BLS QCEW NAICS sector data",
+            "row_count": {"key_columns": {"ownership_title", "naics_sector"}},
+            "negative": {},
+            "null": {},
+        },
+        "qcew_naics3": {
+            "table_name": "BLS QCEW NAICS 3-digit data",
+            "row_count": {"key_columns": {"ownership_title", "naics3"}},
+            "negative": {},
+            "null": {},
+        },
+    }
+
+    for data, params in datasets.items():
+        if data in controls_inputs:
+            tests.validate_data(
+                params["table_name"],
+                controls_inputs[data],
+                row_count=params["row_count"],
+                negative=params["negative"],
+                null=params["null"],
+            )
+
+
+def _create_controls_outputs(
+    controls_inputs: dict[str, pd.DataFrame], year: int
+) -> dict[str, pd.DataFrame]:
+    """Create regional jobs controls by SANDAG employment category.
+
+    There are two methodologies. For years prior to 2022, a methodology is
+    used to account for suppression in the BLS QCEW data. For years 2022 and
+    later, the BLS QCEW data can be used directly. Both methodologies result
+    in regional control totals for SANDAG employment categories that are then
+    combined with military employment data to create the final regional jobs
+    controls.
+
+    Returns:
+        A dictionary containing the regional jobs controls by SANDAG employment
+            category
+    Args:
+        controls_inputs: A dictionary containing input DataFrames related to
+            regional jobs controls
+        year: The year for which to create regional jobs controls
+    """
+    # For years prior to 2022, use methodology to account for BLS QCEW suppression
+    if year < 2022:
+        # This function is called multiple times, so in order to have consistent output it
+        # needs to use it's very own random number generator
+        local_generator = np.random.default_rng(seed=utils.RANDOM_SEED)
+
+        qcew_domain = controls_inputs["qcew_domain"].copy()
+        qcew_supersector = controls_inputs["qcew_supersector"].copy()
+        region_edd = controls_inputs["region_edd"].copy()
+        qcew_naics_sector = controls_inputs["qcew_naics_sector"].copy()
+        qcew_naics3 = controls_inputs["qcew_naics3"].copy()
+
+        # If any QCEW Supersector data is suppressed
+        if qcew_supersector["disclosure_code"].isin(["N"]).any():
+
+            # Aggregate Supersector data to aggregation level 72 (Domain) by ownership
+            # And subtract aggregated Domain jobs from the aggregation level 72 (Domain) jobs by ownership
+            # This provides the total number of jobs that are suppressed within each Domain by ownership
+            domain_diff = (
+                qcew_domain.merge(
+                    qcew_supersector.groupby(["ownership_title", "domain"])
+                    .agg({"jobs": "sum"})
+                    .reset_index(),
+                    how="left",
+                    on=["ownership_title", "domain"],
+                    suffixes=("", "_supersector"),
+                )
+                .assign(jobs_diff=lambda x: x["jobs"] - x["jobs_supersector"])
+                .drop(columns=["jobs", "jobs_supersector"])
+            )
+
+            # Merge suppressed BLS Supersector data with aggregated EDD data
+            qcew_supersector = qcew_supersector.merge(
+                region_edd.groupby(["ownership_title", "supersector"])
+                .agg({"jobs": "sum"})
+                .reset_index(),
+                how="left",
+                on=["ownership_title", "supersector"],
+                suffixes=("", "_edd"),
+            )
+
+            # Scale the EDD data to match the differences
+            # Between the BLS Domain jobs and the aggregated BLS Supersector jobs
+            for ownership in domain_diff["ownership_title"].unique():
+                for domain in domain_diff["domain"].unique():
+                    # Get the index values of the suppressed BLS Supersector data
+                    suppressed_idx = qcew_supersector[
+                        (qcew_supersector["ownership_title"] == ownership)
+                        & (qcew_supersector["domain"] == domain)
+                        & (qcew_supersector["disclosure_code"] == "N")
+                    ].index
+
+                    # Replace suppressed values with scaled EDD values
+                    # Such that aggregated BLS Supersector jobs match BLS Domain jobs
+                    if not suppressed_idx.empty:
+                        qcew_supersector.loc[suppressed_idx, "jobs"] = (
+                            utils.integerize_1d(
+                                data=qcew_supersector.loc[suppressed_idx, "jobs_edd"],
+                                control=domain_diff.loc[
+                                    (domain_diff["ownership_title"] == ownership)
+                                    & (domain_diff["domain"] == domain),
+                                    "jobs_diff",
+                                ].values[0],
+                                methodology="weighted_random",
+                                generator=local_generator,
+                            )
+                        )
+
+            qcew_supersector.drop(columns=["disclosure_code", "jobs_edd"], inplace=True)
+
+        # If any BLS NAICS Sector data is suppressed
+        if qcew_naics_sector["disclosure_code"].isin(["N"]).any():
+
+            # Aggregate BLS NAICS Sector data to aggregation level 73 (Supersector) by ownership
+            # And subtract aggregated Supersector jobs from the aggregation level 73 (Supersector) jobs by ownership
+            # This provides the total number of jobs that are suppressed within each Supersector by ownership
+            supersector_diff = (
+                qcew_supersector.merge(
+                    qcew_naics_sector.groupby(["ownership_title", "supersector"])
+                    .agg({"jobs": "sum"})
+                    .reset_index(),
+                    how="left",
+                    on=["ownership_title", "supersector"],
+                    suffixes=("", "_naics_sector"),
+                )
+                .assign(jobs_diff=lambda x: x["jobs"] - x["jobs_naics_sector"])
+                .drop(columns=["jobs", "jobs_naics_sector"])
+            )
+
+            # Merge suppressed BLS NAICS Sector data with EDD data
+            qcew_naics_sector = qcew_naics_sector.merge(
+                region_edd.groupby(["ownership_title", "naics_sector"])
+                .agg({"jobs": "sum"})
+                .reset_index(),
+                how="left",
+                on=["ownership_title", "naics_sector"],
+                suffixes=("", "_edd"),
+            )
+
+            # Scale the EDD data to match the differences
+            # Between the BLS Supersector jobs and the aggregated BLS NAICS Sector jobs
+            for ownership in supersector_diff["ownership_title"].unique():
+                for supersector in supersector_diff["supersector"].unique():
+                    # Get the index values of the suppressed BLS NAICS Sector data
+                    suppressed_idx = qcew_naics_sector[
+                        (qcew_naics_sector["ownership_title"] == ownership)
+                        & (qcew_naics_sector["supersector"] == supersector)
+                        & (qcew_naics_sector["disclosure_code"] == "N")
+                    ].index
+
+                    # Replace suppressed values with scaled EDD values
+                    # Such that aggregated BLS NAICS Sector jobs match BLS Supersector jobs
+                    if not suppressed_idx.empty:
+                        qcew_naics_sector.loc[suppressed_idx, "jobs"] = (
+                            utils.integerize_1d(
+                                data=qcew_naics_sector.loc[suppressed_idx, "jobs_edd"],
+                                control=supersector_diff.loc[
+                                    (supersector_diff["ownership_title"] == ownership)
+                                    & (supersector_diff["supersector"] == supersector),
+                                    "jobs_diff",
+                                ].values[0],
+                                methodology="weighted_random",
+                                generator=local_generator,
+                            )
+                        )
+
+        # This section only applied to NAICS Sector 72 and NAICS 3-digit 721 and 722
+        # If any BLS NAICS 3-digit data is suppressed
+        if qcew_naics3["disclosure_code"].isin(["N"]).any():
+            # Aggregate BLS NAICS 3-digit data to aggregation level 74 (NAICS Sector) by ownership
+            # And subtract aggregated NAICS Sector jobs from the aggregation level 74 (NAICS Sector) jobs by ownership
+            # This provides the total number of jobs that are suppressed within each NAICS Sector by ownership
+            naics_sector_diff = (
+                qcew_naics_sector.merge(
+                    qcew_naics3.groupby(["ownership_title", "naics_sector"])
+                    .agg({"jobs": "sum"})
+                    .reset_index(),
+                    how="left",
+                    on=["ownership_title", "naics_sector"],
+                    suffixes=("", "_naics3"),
+                )
+                .assign(jobs_diff=lambda x: x["jobs"] - x["jobs_naics3"])
+                .drop(columns=["jobs", "jobs_naics3"])
+            )
+
+            # Merge suppressed BLS NAICS 3-digit data with EDD data
+            qcew_naics3 = qcew_naics3.merge(
+                region_edd.groupby(["ownership_title", "naics3"])
+                .agg({"jobs": "sum"})
+                .reset_index(),
+                how="left",
+                on=["ownership_title", "naics3"],
+                suffixes=("", "_edd"),
+            )
+
+            # Scale the EDD data to match the differences
+            # Between the BLS NAICS Sector jobs and the aggregated BLS NAICS 3-digit jobs
+            for ownership in naics_sector_diff["ownership_title"].unique():
+                for naics_sector in naics_sector_diff["naics_sector"].unique():
+                    # Get the index values of the suppressed BLS NAICS Sector data
+                    suppressed_idx = qcew_naics3[
+                        (qcew_naics3["ownership_title"] == ownership)
+                        & (qcew_naics3["naics_sector"] == naics_sector)
+                        & (qcew_naics3["disclosure_code"] == "N")
+                    ].index
+
+                    # Replace suppressed values with scaled EDD values
+                    # Such that aggregated BLS NAICS 3-digit jobs match BLS NAICS Sector jobs
+                    if not suppressed_idx.empty:
+                        qcew_naics3.loc[suppressed_idx, "jobs"] = utils.integerize_1d(
+                            data=qcew_naics3.loc[suppressed_idx, "jobs_edd"],
+                            control=naics_sector_diff.loc[
+                                (naics_sector_diff["ownership_title"] == ownership)
+                                & (naics_sector_diff["naics_sector"] == naics_sector),
+                                "jobs_diff",
+                            ].values[0],
+                            methodology="weighted_random",
+                            generator=local_generator,
+                        )
+
+        # Combine the NAICS Sector and NAICS 3-digit data
+        result_set = (
+            pd.concat(
+                [
+                    qcew_naics_sector.loc[
+                        qcew_naics_sector["naics_sector"] != "72"
+                    ].rename(columns={"naics_sector": "industry_code"})[
+                        ["ownership_title", "industry_code", "jobs"]
+                    ],
+                    qcew_naics3.rename(columns={"naics3": "industry_code"})[
+                        ["ownership_title", "industry_code", "jobs"]
+                    ],
+                ],
+                ignore_index=True,
+            )
+            .assign(run_id=utils.RUN_ID, year=year, metric="jobs")
+            .rename(columns={"jobs": "value"})[
+                [
+                    "run_id",
+                    "year",
+                    "ownership_title",
+                    "industry_code",
+                    "metric",
+                    "value",
+                ]
+            ]
+        )
+
+        # Aggregate to SANDAG employment categories
+
+        # Following NAICS codes include all ownership categories
+        result_set.loc[
+            result_set["industry_code"].isin(["61", "62", "71", "721", "722"]),
+            "ownership_title",
+        ] = "Total Covered"
+
+        # All other NAICS codes are Private only
+        # Government ownership is aggregated across NAICS codes
+        result_set.loc[
+            result_set["ownership_title"].isin(
+                ["Federal Government", "State Government", "Local Government"]
+            ),
+            "industry_code",
+        ] = "GOV"
+
+        # Remove NAICS 99 and Private ownership 92
+        result_set = result_set.loc[
+            ~(
+                (result_set["industry_code"] == "99")
+                | (
+                    (result_set["ownership_title"] == "Private")
+                    & (result_set["industry_code"] == "92")
+                )
+            )
+        ]
+
+        result_set = (
+            result_set.groupby(
+                ["run_id", "year", "ownership_title", "industry_code", "metric"]
+            )["value"]
+            .sum()
+            .reset_index()
+        )
+
+    # For years 2022 and later, use the BLS QCEW data directly
+    else:
+        result_set = controls_inputs["region_qcew"].copy()
+
+    # Combine the regional jobs controls with military employment data and return
+    return {
+        "results": pd.concat(
+            [
+                result_set,
+                controls_inputs["military"]
+                .groupby(
+                    ["run_id", "year", "ownership_title", "industry_code", "metric"]
+                )["value"]
+                .sum()
+                .reset_index(),
+            ],
+            ignore_index=True,
+        )
+    }
+
+
+def _validate_controls_outputs(controls_outputs: dict[str, pd.DataFrame]) -> None:
+    """Validate the regional jobs controls output data."""
+    tests.validate_data(
+        "Regional jobs controls by SANDAG employment category",
+        controls_outputs["results"],
+        row_count={"key_columns": {("ownership_title", "industry_code")}},
+        negative={},
+        null={},
+    )
+
+
+def _insert_controls(controls_outputs: dict[str, pd.DataFrame], debug: bool) -> None:
+    """Insert the regional jobs controls data into the database."""
+    # Save locally if in debug mode
+    if debug:
+        controls_outputs["results"].to_csv(
+            utils.DEBUG_OUTPUT_FOLDER / "inputs_controls_jobs.csv", index=False
+        )
+
+    # Otherwise, insert to database
+    else:
+        with utils.ESTIMATES_ENGINE.connect() as con:
+            controls_outputs["results"].to_sql(
+                name="controls_jobs",
+                con=con,
+                schema="inputs",
+                if_exists="append",
+                index=False,
+            )
 
 
 def _get_lodes_data(year: int) -> pd.DataFrame:
@@ -172,18 +654,13 @@ def _get_jobs_inputs(year: int) -> dict[str, pd.DataFrame]:
     # Store results here
     jobs_inputs = {}
 
-    jobs_inputs["lodes_data"] = _get_lodes_data(year)
+    # Get regional employment control totals
+    jobs_inputs["control_totals"] = _create_controls_outputs(
+        _get_controls_inputs(year), year
+    )["results"]
 
-    with utils.ESTIMATES_ENGINE.connect() as con:
-        # Get regional employment control totals from QCEW
-        with open(utils.SQL_FOLDER / "employment/get_region_qcew.sql") as file:
-            jobs_inputs["control_totals"] = utils.read_sql_query_fallback(
-                sql=sql.text(file.read()),
-                con=con,
-                params={
-                    "year": year,
-                },
-            ).assign(run_id=utils.RUN_ID)
+    # Get LEHD LODES data with industry code 72 split into 721 and 722
+    jobs_inputs["lodes_data"] = _get_lodes_data(year)
 
     with utils.GIS_ENGINE.connect() as con:
         # Get crosswalk from Census blocks to MGRAs
@@ -198,7 +675,7 @@ def _get_jobs_inputs(year: int) -> dict[str, pd.DataFrame]:
                 },
             )
 
-        # Get military employment data and append to control_totals
+        # Get military employment at the MGRA level
         with open(utils.SQL_FOLDER / "employment/get_military_employment.sql") as file:
             jobs_inputs["military_emp"] = pd.read_sql_query(
                 sql=sql.text(file.read()),
@@ -209,20 +686,6 @@ def _get_jobs_inputs(year: int) -> dict[str, pd.DataFrame]:
                     "series": utils.SERIES,
                 },
             )
-
-        military_control_totals = (
-            jobs_inputs["military_emp"]
-            .groupby(
-                ["run_id", "year", "ownership_title", "industry_code", "metric"],
-                as_index=False,
-            )["value"]
-            .sum()
-        )[["run_id", "year", "ownership_title", "industry_code", "metric", "value"]]
-
-        jobs_inputs["control_totals"] = pd.concat(
-            [jobs_inputs["control_totals"], military_control_totals],
-            ignore_index=True,
-        )
 
     return jobs_inputs
 
@@ -345,17 +808,13 @@ def _validate_jobs_outputs(jobs_outputs: dict[str, pd.DataFrame]) -> None:
 
 
 def _insert_jobs(
-    jobs_inputs: dict[str, pd.DataFrame],
     jobs_outputs: dict[str, pd.DataFrame],
     debug: bool,
 ) -> None:
-    """Insert input and output data related to jobs to the database."""
+    """Insert output data related to jobs to the database."""
 
     # Save locally if in debug mode
     if debug:
-        jobs_inputs["control_totals"].to_csv(
-            utils.DEBUG_OUTPUT_FOLDER / "inputs_controls_jobs.csv", index=False
-        )
         jobs_outputs["results"].to_csv(
             utils.DEBUG_OUTPUT_FOLDER / "outputs_jobs.csv", index=False
         )
@@ -363,15 +822,6 @@ def _insert_jobs(
     # Otherwise, insert to database
     else:
         with utils.ESTIMATES_ENGINE.connect() as con:
-
-            jobs_inputs["control_totals"].to_sql(
-                name="controls_jobs",
-                con=con,
-                schema="inputs",
-                if_exists="append",
-                index=False,
-            )
-
             jobs_outputs["results"].to_sql(
                 name="jobs", con=con, schema="outputs", if_exists="append", index=False
             )

--- a/python/employment.py
+++ b/python/employment.py
@@ -421,14 +421,13 @@ def _create_controls_outputs(
                 ],
                 ignore_index=True,
             )
-            .assign(run_id=utils.RUN_ID, year=year, metric="jobs")
+            .assign(run_id=utils.RUN_ID, year=year)
             .rename(columns={"jobs": "value"})[
                 [
                     "run_id",
                     "year",
                     "ownership_title",
                     "industry_code",
-                    "metric",
                     "value",
                 ]
             ]
@@ -463,9 +462,9 @@ def _create_controls_outputs(
         ] = "GOV"
 
         result_set = (
-            result_set.groupby(
-                ["run_id", "year", "ownership_title", "industry_code", "metric"]
-            )["value"]
+            result_set.groupby(["run_id", "year", "ownership_title", "industry_code"])[
+                "value"
+            ]
             .sum()
             .reset_index()
         )
@@ -477,9 +476,7 @@ def _create_controls_outputs(
     # Aggregate military employment to the regional level
     military = (
         controls_inputs["military"]
-        .groupby(["run_id", "year", "ownership_title", "industry_code", "metric"])[
-            "value"
-        ]
+        .groupby(["run_id", "year", "ownership_title", "industry_code"])["value"]
         .sum()
         .reset_index()
     )

--- a/python/employment.py
+++ b/python/employment.py
@@ -229,7 +229,7 @@ def _create_controls_outputs(
     # For years prior to 2022, use methodology to account for BLS QCEW suppression
     if year < 2022:
         # This function is called multiple times, so in order to have consistent output it
-        # needs to use it's very own random number generator
+        # needs to use its own random number generator
         local_generator = np.random.default_rng(seed=utils.RANDOM_SEED)
 
         qcew_domain = controls_inputs["qcew_domain"].copy()

--- a/python/employment.py
+++ b/python/employment.py
@@ -21,7 +21,7 @@ def run_employment(year: int, debug: bool):
 
     Functionality is split apart for code encapsulation (function inputs not included):
         _get_jobs_inputs - Get all input data related to jobs, including LODES data,
-            block to MGRA crosswalk, and control totals from the BLSQCEW. Then process
+            block to MGRA crosswalk, and control totals from the BLS QCEW. Then process
             the LODES data to the MGRA level by industry_code.
         _validate_jobs_inputs - Validate the input tables from the above function
         _create_jobs_output - Apply control totals to employment data using

--- a/python/employment.py
+++ b/python/employment.py
@@ -195,14 +195,14 @@ def _validate_controls_inputs(controls_inputs: dict[str, pd.DataFrame]) -> None:
         },
     }
 
-    for data, params in datasets.items():
-        if data in controls_inputs:
+    for dataset, parameters in datasets.items():
+        if dataset in controls_inputs:
             tests.validate_data(
-                params["table_name"],
-                controls_inputs[data],
-                row_count=params["row_count"],
-                negative=params["negative"],
-                null=params["null"],
+                parameters["table_name"],
+                controls_inputs[dataset],
+                row_count=parameters["row_count"],
+                negative=parameters["negative"],
+                null=parameters["null"],
             )
 
 

--- a/python/employment.py
+++ b/python/employment.py
@@ -17,12 +17,12 @@ def run_employment(year: int, debug: bool):
     """Control function to create jobs data by industry_code at the MGRA level.
 
     Get the LEHD LODES data, aggregate to the MGRA level using the block to MGRA
-    crosswalk, then apply control totals from QCEW using integerization.
+    crosswalk, then apply control totals from the BLS QCEW using integerization.
 
     Functionality is split apart for code encapsulation (function inputs not included):
         _get_jobs_inputs - Get all input data related to jobs, including LODES data,
-            block to MGRA crosswalk, and control totals from QCEW. Then process the
-            LODES data to the MGRA level by industry_code.
+            block to MGRA crosswalk, and control totals from the BLSQCEW. Then process
+            the LODES data to the MGRA level by industry_code.
         _validate_jobs_inputs - Validate the input tables from the above function
         _create_jobs_output - Apply control totals to employment data using
             utils.integerize_1d() and create output table
@@ -65,7 +65,7 @@ def _get_controls_inputs(year: int) -> dict[str, pd.DataFrame]:
     # Initialize return dictionary
     controls_inputs = {}
 
-    # Years prior to 2022 use methodology to account for BLS QCEW suppression
+    # Years prior to 2022 use methodology to account for suppression
     # And cannot use the BLS QCEW data directly
     if year < 2022:
         queries = {
@@ -123,22 +123,22 @@ def _get_controls_inputs(year: int) -> dict[str, pd.DataFrame]:
             },
         }
 
-    for key, value in queries.items():
-        if value["server"] == utils.ESTIMATES_SERVER:
+    for dataset_name, query_config in queries.items():
+        if query_config["server"] == utils.ESTIMATES_SERVER:
             with utils.ESTIMATES_ENGINE.connect() as con:
-                with open(utils.SQL_FOLDER / value["query"]) as file:
-                    controls_inputs[key] = utils.read_sql_query_fallback(
+                with open(utils.SQL_FOLDER / query_config["query"]) as file:
+                    controls_inputs[dataset_name] = utils.read_sql_query_fallback(
                         sql=sql.text(file.read()),
                         con=con,
-                        params=value["params"],
+                        params=query_config["params"],
                     )
-        elif value["server"] == utils.GIS_SERVER:
+        elif query_config["server"] == utils.GIS_SERVER:
             with utils.GIS_ENGINE.connect() as con:
-                with open(utils.SQL_FOLDER / value["query"]) as file:
-                    controls_inputs[key] = utils.read_sql_query_fallback(
+                with open(utils.SQL_FOLDER / query_config["query"]) as file:
+                    controls_inputs[dataset_name] = utils.read_sql_query_fallback(
                         sql=sql.text(file.read()),
                         con=con,
-                        params=value["params"],
+                        params=query_config["params"],
                     )
 
     return controls_inputs
@@ -238,7 +238,7 @@ def _create_controls_outputs(
         qcew_naics_sector = controls_inputs["qcew_naics_sector"].copy()
         qcew_naics3 = controls_inputs["qcew_naics3"].copy()
 
-        # If any QCEW Supersector data is suppressed
+        # If any BLS QCEW Supersector data is suppressed
         if qcew_supersector["disclosure_code"].isin(["N"]).any():
 
             # Aggregate Supersector data to aggregation level 72 (Domain) by ownership
@@ -246,8 +246,8 @@ def _create_controls_outputs(
             # This provides the total number of jobs that are suppressed within each Domain by ownership
             domain_diff = (
                 qcew_domain.merge(
-                    qcew_supersector.groupby(["ownership_title", "domain"])
-                    .agg({"jobs": "sum"})
+                    qcew_supersector.groupby(["ownership_title", "domain"])["jobs"]
+                    .sum()
                     .reset_index(),
                     how="left",
                     on=["ownership_title", "domain"],
@@ -257,10 +257,10 @@ def _create_controls_outputs(
                 .drop(columns=["jobs", "jobs_supersector"])
             )
 
-            # Merge suppressed BLS Supersector data with aggregated EDD data
+            # Merge suppressed Supersector data with aggregated EDD data
             qcew_supersector = qcew_supersector.merge(
-                region_edd.groupby(["ownership_title", "supersector"])
-                .agg({"jobs": "sum"})
+                region_edd.groupby(["ownership_title", "supersector"])["jobs"]
+                .sum()
                 .reset_index(),
                 how="left",
                 on=["ownership_title", "supersector"],
@@ -268,10 +268,10 @@ def _create_controls_outputs(
             )
 
             # Scale the EDD data to match the differences
-            # Between the BLS Domain jobs and the aggregated BLS Supersector jobs
+            # Between the Domain jobs and the aggregated Supersector jobs
             for ownership in domain_diff["ownership_title"].unique():
                 for domain in domain_diff["domain"].unique():
-                    # Get the index values of the suppressed BLS Supersector data
+                    # Get the index values of the suppressed Supersector data
                     suppressed_idx = qcew_supersector[
                         (qcew_supersector["ownership_title"] == ownership)
                         & (qcew_supersector["domain"] == domain)
@@ -279,7 +279,7 @@ def _create_controls_outputs(
                     ].index
 
                     # Replace suppressed values with scaled EDD values
-                    # Such that aggregated BLS Supersector jobs match BLS Domain jobs
+                    # Such that aggregated Supersector jobs to match Domain jobs
                     if not suppressed_idx.empty:
                         qcew_supersector.loc[suppressed_idx, "jobs"] = (
                             utils.integerize_1d(
@@ -296,10 +296,10 @@ def _create_controls_outputs(
 
             qcew_supersector.drop(columns=["disclosure_code", "jobs_edd"], inplace=True)
 
-        # If any BLS NAICS Sector data is suppressed
+        # If any QCEW NAICS Sector data is suppressed
         if qcew_naics_sector["disclosure_code"].isin(["N"]).any():
 
-            # Aggregate BLS NAICS Sector data to aggregation level 73 (Supersector) by ownership
+            # Aggregate NAICS Sector data to aggregation level 73 (Supersector) by ownership
             # And subtract aggregated Supersector jobs from the aggregation level 73 (Supersector) jobs by ownership
             # This provides the total number of jobs that are suppressed within each Supersector by ownership
             supersector_diff = (
@@ -315,7 +315,7 @@ def _create_controls_outputs(
                 .drop(columns=["jobs", "jobs_naics_sector"])
             )
 
-            # Merge suppressed BLS NAICS Sector data with EDD data
+            # Merge suppressed NAICS Sector data with EDD data
             qcew_naics_sector = qcew_naics_sector.merge(
                 region_edd.groupby(["ownership_title", "naics_sector"])
                 .agg({"jobs": "sum"})
@@ -326,10 +326,10 @@ def _create_controls_outputs(
             )
 
             # Scale the EDD data to match the differences
-            # Between the BLS Supersector jobs and the aggregated BLS NAICS Sector jobs
+            # Between the Supersector jobs and the aggregated NAICS Sector jobs
             for ownership in supersector_diff["ownership_title"].unique():
                 for supersector in supersector_diff["supersector"].unique():
-                    # Get the index values of the suppressed BLS NAICS Sector data
+                    # Get the index values of the suppressed NAICS Sector data
                     suppressed_idx = qcew_naics_sector[
                         (qcew_naics_sector["ownership_title"] == ownership)
                         & (qcew_naics_sector["supersector"] == supersector)
@@ -337,7 +337,7 @@ def _create_controls_outputs(
                     ].index
 
                     # Replace suppressed values with scaled EDD values
-                    # Such that aggregated BLS NAICS Sector jobs match BLS Supersector jobs
+                    # Such that aggregated NAICS Sector jobs match Supersector jobs
                     if not suppressed_idx.empty:
                         qcew_naics_sector.loc[suppressed_idx, "jobs"] = (
                             utils.integerize_1d(
@@ -352,10 +352,10 @@ def _create_controls_outputs(
                             )
                         )
 
-        # This section only applied to NAICS Sector 72 and NAICS 3-digit 721 and 722
-        # If any BLS NAICS 3-digit data is suppressed
+        # This section only applies to NAICS Sector 72 and NAICS 3-digit 721 and 722
+        # If any NAICS 3-digit data is suppressed
         if qcew_naics3["disclosure_code"].isin(["N"]).any():
-            # Aggregate BLS NAICS 3-digit data to aggregation level 74 (NAICS Sector) by ownership
+            # Aggregate NAICS 3-digit data to aggregation level 74 (NAICS Sector) by ownership
             # And subtract aggregated NAICS Sector jobs from the aggregation level 74 (NAICS Sector) jobs by ownership
             # This provides the total number of jobs that are suppressed within each NAICS Sector by ownership
             naics_sector_diff = (
@@ -371,7 +371,7 @@ def _create_controls_outputs(
                 .drop(columns=["jobs", "jobs_naics3"])
             )
 
-            # Merge suppressed BLS NAICS 3-digit data with EDD data
+            # Merge suppressed NAICS 3-digit data with EDD data
             qcew_naics3 = qcew_naics3.merge(
                 region_edd.groupby(["ownership_title", "naics3"])
                 .agg({"jobs": "sum"})
@@ -382,10 +382,10 @@ def _create_controls_outputs(
             )
 
             # Scale the EDD data to match the differences
-            # Between the BLS NAICS Sector jobs and the aggregated BLS NAICS 3-digit jobs
+            # Between the NAICS Sector jobs and the aggregated NAICS 3-digit jobs
             for ownership in naics_sector_diff["ownership_title"].unique():
                 for naics_sector in naics_sector_diff["naics_sector"].unique():
-                    # Get the index values of the suppressed BLS NAICS Sector data
+                    # Get the index values of the suppressed NAICS Sector data
                     suppressed_idx = qcew_naics3[
                         (qcew_naics3["ownership_title"] == ownership)
                         & (qcew_naics3["naics_sector"] == naics_sector)
@@ -393,7 +393,7 @@ def _create_controls_outputs(
                     ].index
 
                     # Replace suppressed values with scaled EDD values
-                    # Such that aggregated BLS NAICS 3-digit jobs match BLS NAICS Sector jobs
+                    # Such that aggregated NAICS 3-digit jobs match NAICS Sector jobs
                     if not suppressed_idx.empty:
                         qcew_naics3.loc[suppressed_idx, "jobs"] = utils.integerize_1d(
                             data=qcew_naics3.loc[suppressed_idx, "jobs_edd"],
@@ -470,22 +470,24 @@ def _create_controls_outputs(
             .reset_index()
         )
 
-    # For years 2022 and later, use the BLS QCEW data directly
+    # For years 2022 and later, use the QCEW data directly
     else:
         result_set = controls_inputs["region_qcew"].copy()
+
+    # Aggregate military employment to the regional level
+    military = (
+        controls_inputs["military"]
+        .groupby(["run_id", "year", "ownership_title", "industry_code", "metric"])[
+            "value"
+        ]
+        .sum()
+        .reset_index()
+    )
 
     # Combine the regional jobs controls with military employment data and return
     return {
         "results": pd.concat(
-            [
-                result_set,
-                controls_inputs["military"]
-                .groupby(
-                    ["run_id", "year", "ownership_title", "industry_code", "metric"]
-                )["value"]
-                .sum()
-                .reset_index(),
-            ],
+            [result_set, military],
             ignore_index=True,
         )
     }

--- a/python/tests.py
+++ b/python/tests.py
@@ -48,7 +48,7 @@ _DISTINCT_COUNTS = {
         "naics_sector": 21,
         # SANDAG uses only 721/722
         "naics3": 2,
-        # Combined NAICS sectors used by SANDAG + "99"
+        # NAICS sectors with 72 split into 721 and 722
         ("naics3", "naics_sector"): 22,
     },
     "series": {

--- a/python/tests.py
+++ b/python/tests.py
@@ -40,6 +40,16 @@ _DISTINCT_COUNTS = {
         # See https://github.com/SANDAG/Estimates-Program/issues/281
         # For exhaustive list of SANDAG employment categories + Military
         ("ownership_title", "industry_code"): 24,
+        # SANDAG uses only four ownership titles
+        "ownership_title": 4,
+        # See https://www.bls.gov/cew/classifications/industry/high-level-industries.htm
+        "domain": 2,
+        "supersector": 12,
+        "naics_sector": 21,
+        # SANDAG uses only 721/722
+        "naics3": 2,
+        # Combined NAICS sectors used by SANDAG + "99"
+        ("naics3", "naics_sector"): 22,
     },
     "series": {
         15: {
@@ -106,6 +116,9 @@ def validate_data(table_name: str, data: pd.DataFrame, **kwargs) -> None:
             raise ValueError(
                 f"The test '{test_name}' was requested but cannot be found."
             )
+
+    # If test is passed as None, then it is not run and allows explicit disabling of tests
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
 
     # For each test, make sure that the correct input values are passed
     for test_name, test in all_tests.items():
@@ -248,7 +261,7 @@ def _validate_row_count(
 
 
 def _validate_negative(
-    table_name: str, data: pd.DataFrame, negative_ok: list[str] = None
+    table_name: str, data: pd.DataFrame, negative_ok: set = None
 ) -> None:
     """Verify that the provided data does not contain negative values
 
@@ -268,7 +281,7 @@ def _validate_negative(
     """
     # Avoid issues with mutable default parameter values
     if negative_ok is None:
-        negative_ok = []
+        negative_ok = set()
 
     # Check each column of the input data
     for column in data.columns:
@@ -294,9 +307,7 @@ def _validate_negative(
                 )
 
 
-def _validate_null(
-    table_name: str, data: pd.DataFrame, null_ok: list[str] = None
-) -> None:
+def _validate_null(table_name: str, data: pd.DataFrame, null_ok: set = None) -> None:
     """Verify that the provided data does not contain null values
 
     Checks will be performed on all columns unless they are explicitly passed into the
@@ -314,7 +325,7 @@ def _validate_null(
     """
     # Avoid issues with mutable default parameter values
     if null_ok is None:
-        null_ok = []
+        null_ok = set()
 
     # Check each column of the input data
     for column in data.columns:

--- a/python/utils.py
+++ b/python/utils.py
@@ -76,7 +76,8 @@ GIS_ENGINE = sql.create_engine(
     fast_executemany=True,
 )
 
-# Other SQL configuration
+# Other SQL configuration(s)
+ESTIMATES_SERVER = _secrets["sql"]["estimates"]["server"]
 GIS_SERVER = _secrets["sql"]["gis"]["server"]
 
 # Temporary file staging location for SQL BULK Inserts

--- a/sql/create_objects.sql
+++ b/sql/create_objects.sql
@@ -40,10 +40,9 @@ CREATE TABLE [inputs].[controls_jobs] (
     [year] INT NOT NULL,
     [ownership_title] NVARCHAR (50) NOT NULL,
     [industry_code] NVARCHAR(5) NOT NULL,
-    [metric] NVARCHAR(4) NOT NULL,
     [value] INT NOT NULL,
     INDEX [ccsi_inputs_controls_jobs] CLUSTERED COLUMNSTORE,
-    CONSTRAINT [ixuq_inputs_controls_jobs] UNIQUE ([run_id], [year], [ownership_title], [industry_code], [metric]) WITH (DATA_COMPRESSION = PAGE),
+    CONSTRAINT [ixuq_inputs_controls_jobs] UNIQUE ([run_id], [year], [ownership_title], [industry_code]) WITH (DATA_COMPRESSION = PAGE),
     CONSTRAINT [fk_inputs_controls_jobs_run_id] FOREIGN KEY ([run_id]) REFERENCES [metadata].[run] ([run_id]),
     CONSTRAINT [chk_non_negative_inputs_controls_jobs] CHECK ([value] >= 0)
 )

--- a/sql/employment/get_bls_qcew_domain.sql
+++ b/sql/employment/get_bls_qcew_domain.sql
@@ -25,62 +25,62 @@ IF NOT EXISTS (
 SELECT @msg AS [msg]
 ELSE
 BEGIN
-	-- Ensure no records are suppressed
-	IF EXISTS (
-		SELECT *
-		FROM [socioec_data].[bls].[qcew_by_area_annual]
-		WHERE
-			[year] = @year
-			AND [area_fips] = '06073'
-			AND [agglvl_code] = 72
-			AND [disclosure_code] = 'N'
-	) THROW 50000, 'Control totals using [agglvl_code]=72 are suppressed', 1;
+    -- Ensure no records are suppressed
+    IF EXISTS (
+        SELECT TOP(1) *
+        FROM [socioec_data].[bls].[qcew_by_area_annual]
+        WHERE
+            [year] = @year
+            AND [area_fips] = '06073'  -- San Diego County
+            AND [agglvl_code] = 72 -- Aggregation level 72 (Domain)
+            AND [disclosure_code] = 'N'  -- https://www.bls.gov/cew/questions-and-answers.htm#Q13
+    ) THROW 50000, 'Control totals using [agglvl_code]=72 are suppressed', 1;
 
 
-	-- Create shell table of all ownership and domain combinations
-	DROP TABLE IF EXISTS [#tt_shell]
-	SELECT [ownership_title], [domain]
-	INTO [#tt_shell]
-	FROM (
-		SELECT [ownership_title] FROM (
-			VALUES
-				('Federal Government'),
-				('State Government'),
-				('Local Government'),
-				('Private')
-		) AS [tt1] ([ownership_title])
-	) AS [ownership_title]
-	CROSS JOIN (
-		SELECT DISTINCT [domain]
-		FROM [socioec_data].[bls].[naics_aggregation]
-	) AS [domain];
+    -- Create shell table of all ownership and domain combinations
+    DROP TABLE IF EXISTS [#tt_shell]
+    SELECT [ownership_title], [domain]
+    INTO [#tt_shell]
+    FROM (
+        VALUES
+            ('Federal Government'),
+            ('State Government'),
+            ('Local Government'),
+            ('Private')
+    ) AS [tt1] ([ownership_title])
+    CROSS JOIN (
+        SELECT DISTINCT [domain]
+        FROM [socioec_data].[bls].[naics_aggregation]
+    ) AS [domain];
 
 
-	-- Get Annual QCEW totals by ownership and domain
-	WITH [qcew] AS (
-		SELECT
-			[ownership_title],
-			[industry_code],
-			[annual_avg_emplvl]
-		FROM [socioec_data].[bls].[qcew_by_area_annual]
-		INNER JOIN [socioec_data].[bls].[industry_code]
-			ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
-		INNER JOIN [socioec_data].[bls].[ownership_titles]
-			ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
-		WHERE
-			[year] = @year
-			AND [area_fips] = '06073'
-			AND [agglvl_code] = 72
-	)
-	SELECT
-		[#tt_shell].[ownership_title],
-		[#tt_shell].[domain],
-		ISNULL([annual_avg_emplvl], 0) AS [jobs]
-	FROM [#tt_shell]
-	LEFT OUTER JOIN [qcew]
-		ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
-		AND [#tt_shell].[domain] = [qcew].[industry_code]
-	ORDER BY
-		[ownership_title],
-		[domain]
+    -- Get Annual QCEW totals by ownership and domain
+    WITH [qcew] AS (
+        SELECT
+            [ownership_title],
+            [industry_code],
+            [annual_avg_emplvl]
+        FROM [socioec_data].[bls].[qcew_by_area_annual]
+        INNER JOIN [socioec_data].[bls].[industry_code]
+            ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
+        INNER JOIN [socioec_data].[bls].[ownership_titles]
+            ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
+        WHERE
+            [year] = @year
+            AND [area_fips] = '06073'  -- San Diego County
+            AND [agglvl_code] = 72  -- Aggregation level 72 (Domain)
+)
+    SELECT
+        [#tt_shell].[ownership_title],
+        [#tt_shell].[domain],
+        ISNULL([annual_avg_emplvl], 0) AS [jobs]
+    FROM [#tt_shell]
+    LEFT OUTER JOIN [qcew]
+        ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
+        AND [#tt_shell].[domain] = [qcew].[industry_code]
+    ORDER BY
+        [ownership_title],
+        [domain]
+
+    DROP TABLE IF EXISTS [#tt_shell]
 END

--- a/sql/employment/get_bls_qcew_domain.sql
+++ b/sql/employment/get_bls_qcew_domain.sql
@@ -1,0 +1,86 @@
+/*
+Get BLS QCEW jobs by ownership at aggregation level 72 (Domain). Ensure that
+all ownerships and domains are represented, filling in 0s where appropriate.
+Note that the process to create BLS QCEW regional SANDAG employment categories
+relies on this aggregation level containing all non-suppressed values so an
+error is thrown if any suppressed values are encountered.
+
+As of 2010-2025, no suppressed values have been encountered at this aggregation
+level for San Diego County. If this occurs in the future, the process to create
+BLS QCEW regional SANDAG employment categories will need to be revised to start
+at the next higher aggregation level (agglvl_code=71 or 70).
+*/
+
+SET NOCOUNT ON;
+-- Initialize parameters -----------------------------------------------------
+DECLARE @year integer = :year; 
+DECLARE @msg nvarchar(25) = 'QCEW data does not exist';
+
+-- Send error message if no data exists --------------------------------------
+IF NOT EXISTS (
+    SELECT TOP (1) *
+    FROM [socioec_data].[bls].[qcew_by_area_annual]
+    WHERE [year] = @year
+)
+SELECT @msg AS [msg]
+ELSE
+BEGIN
+	-- Ensure no records are suppressed
+	IF EXISTS (
+		SELECT *
+		FROM [socioec_data].[bls].[qcew_by_area_annual]
+		WHERE
+			[year] = @year
+			AND [area_fips] = '06073'
+			AND [agglvl_code] = 72
+			AND [disclosure_code] = 'N'
+	) THROW 50000, 'Control totals using [agglvl_code]=72 are suppressed', 1;
+
+
+	-- Create shell table of all ownership and domain combinations
+	DROP TABLE IF EXISTS [#tt_shell]
+	SELECT [ownership_title], [domain]
+	INTO [#tt_shell]
+	FROM (
+		SELECT [ownership_title] FROM (
+			VALUES
+				('Federal Government'),
+				('State Government'),
+				('Local Government'),
+				('Private')
+		) AS [tt1] ([ownership_title])
+	) AS [ownership_title]
+	CROSS JOIN (
+		SELECT DISTINCT [domain]
+		FROM [socioec_data].[bls].[naics_aggregation]
+	) AS [domain];
+
+
+	-- Get Annual QCEW totals by ownership and domain
+	WITH [qcew] AS (
+		SELECT
+			[ownership_title],
+			[industry_code],
+			[annual_avg_emplvl]
+		FROM [socioec_data].[bls].[qcew_by_area_annual]
+		INNER JOIN [socioec_data].[bls].[industry_code]
+			ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
+		INNER JOIN [socioec_data].[bls].[ownership_titles]
+			ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
+		WHERE
+			[year] = @year
+			AND [area_fips] = '06073'
+			AND [agglvl_code] = 72
+	)
+	SELECT
+		[#tt_shell].[ownership_title],
+		[#tt_shell].[domain],
+		ISNULL([annual_avg_emplvl], 0) AS [jobs]
+	FROM [#tt_shell]
+	LEFT OUTER JOIN [qcew]
+		ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
+		AND [#tt_shell].[domain] = [qcew].[industry_code]
+	ORDER BY
+		[ownership_title],
+		[domain]
+END

--- a/sql/employment/get_bls_qcew_naics3.sql
+++ b/sql/employment/get_bls_qcew_naics3.sql
@@ -1,0 +1,87 @@
+/*
+Get BLS QCEW jobs by ownership at aggregation level 75 (NAICS 3-digit). This
+is only for codes 721 and 722 as NAICS sector 72 is the only sector SANDAG
+splits out into three digit NAICS. Ensure that all ownerships are represented,
+filling in 0s where appropriate. An indicator of data suppression is returned
+along with the data.
+*/
+
+SET NOCOUNT ON;
+-- Initialize parameters -----------------------------------------------------
+DECLARE @year integer = :year; 
+DECLARE @msg nvarchar(25) = 'QCEW data does not exist';
+
+-- Send error message if no data exists --------------------------------------
+IF NOT EXISTS (
+    SELECT TOP (1) *
+    FROM [socioec_data].[bls].[qcew_by_area_annual]
+    WHERE [year] = @year
+)
+SELECT @msg AS [msg]
+ELSE
+BEGIN
+	-- Create shell table of all ownership and naics 3-digit combinations
+	-- Only 721 and 722 are of interest
+	DROP TABLE IF EXISTS [#tt_shell]
+	SELECT [ownership_title], [naics3], [naics_sector], [supersector], [domain]
+	INTO [#tt_shell]
+	FROM (
+		SELECT [ownership_title] FROM (
+			VALUES
+				('Federal Government'),
+				('State Government'),
+				('Local Government'),
+				('Private')
+		) AS [tt1] ([ownership_title])
+	) AS [ownership_title]
+	CROSS JOIN (
+		SELECT DISTINCT [naics_sector], [supersector], [domain]
+		FROM [socioec_data].[bls].[naics_aggregation]
+	) AS [naics_sector]
+	INNER JOIN (
+		SELECT [naics3] FROM (
+			VALUES
+				('721'),
+				('722')
+		) AS [tt2] ([naics3])
+	) AS [naics3]
+	ON [naics_sector].[naics_sector] = '72';
+
+
+	-- Get Annual QCEW totals by ownership and naics 3-digit for 721 and 722
+	WITH [qcew] AS (
+		SELECT
+			[ownership_title],
+			[industry_code],
+			[annual_avg_emplvl],
+			[disclosure_code]
+		FROM [socioec_data].[bls].[qcew_by_area_annual]
+		INNER JOIN [socioec_data].[bls].[industry_code]
+			ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
+		INNER JOIN [socioec_data].[bls].[ownership_titles]
+			ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
+		WHERE
+			[year] = @year
+			AND [area_fips] = '06073'
+			AND [agglvl_code] = 75
+			AND [industry_code] IN ('721', '722')
+	)
+	SELECT
+		[#tt_shell].[ownership_title],
+		[#tt_shell].[naics3],
+		[#tt_shell].[naics_sector],
+		[#tt_shell].[supersector],
+		[#tt_shell].[domain],
+		ISNULL([annual_avg_emplvl], 0) AS [jobs],
+		ISNULL([disclosure_code], '') AS [disclosure_code]
+	FROM [#tt_shell]
+	LEFT OUTER JOIN [qcew]
+		ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
+		AND [#tt_shell].[naics3] = [qcew].[industry_code]
+	ORDER BY
+		[ownership_title],
+		[naics3],
+		[naics_sector],
+		[supersector],
+		[domain]
+END

--- a/sql/employment/get_bls_qcew_naics3.sql
+++ b/sql/employment/get_bls_qcew_naics3.sql
@@ -1,7 +1,7 @@
 /*
 Get BLS QCEW jobs by ownership at aggregation level 75 (NAICS 3-digit). This
 is only for codes 721 and 722 as NAICS sector 72 is the only sector SANDAG
-splits out into three digit NAICS. Ensure that all ownerships are represented,
+splits out into 3-digit NAICS. Ensure that all ownerships are represented,
 filling in 0s where appropriate. An indicator of data suppression is returned
 along with the data.
 */
@@ -20,68 +20,66 @@ IF NOT EXISTS (
 SELECT @msg AS [msg]
 ELSE
 BEGIN
-	-- Create shell table of all ownership and naics 3-digit combinations
-	-- Only 721 and 722 are of interest
-	DROP TABLE IF EXISTS [#tt_shell]
-	SELECT [ownership_title], [naics3], [naics_sector], [supersector], [domain]
-	INTO [#tt_shell]
-	FROM (
-		SELECT [ownership_title] FROM (
-			VALUES
-				('Federal Government'),
-				('State Government'),
-				('Local Government'),
-				('Private')
-		) AS [tt1] ([ownership_title])
-	) AS [ownership_title]
-	CROSS JOIN (
-		SELECT DISTINCT [naics_sector], [supersector], [domain]
-		FROM [socioec_data].[bls].[naics_aggregation]
-	) AS [naics_sector]
-	INNER JOIN (
-		SELECT [naics3] FROM (
-			VALUES
-				('721'),
-				('722')
-		) AS [tt2] ([naics3])
-	) AS [naics3]
-	ON [naics_sector].[naics_sector] = '72';
+    -- Create shell table of all ownership and NAICS 3-digit combinations
+    -- Only 721 and 722 are of interest
+    DROP TABLE IF EXISTS [#tt_shell]
+    SELECT [ownership_title], [naics3], [naics_sector], [supersector], [domain]
+    INTO [#tt_shell]
+    FROM (
+        VALUES
+            ('Federal Government'),
+            ('State Government'),
+            ('Local Government'),
+            ('Private')
+    ) AS [tt1] ([ownership_title])
+    CROSS JOIN (
+        SELECT [naics_sector], [supersector], [domain]
+        FROM [socioec_data].[bls].[naics_aggregation]
+    ) AS [naics_sector]
+    INNER JOIN (
+        VALUES
+            ('721'),
+            ('722')
+    ) AS [tt2] ([naics3])
+    ON [naics_sector].[naics_sector] = '72';
 
 
-	-- Get Annual QCEW totals by ownership and naics 3-digit for 721 and 722
-	WITH [qcew] AS (
-		SELECT
-			[ownership_title],
-			[industry_code],
-			[annual_avg_emplvl],
-			[disclosure_code]
-		FROM [socioec_data].[bls].[qcew_by_area_annual]
-		INNER JOIN [socioec_data].[bls].[industry_code]
-			ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
-		INNER JOIN [socioec_data].[bls].[ownership_titles]
-			ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
-		WHERE
-			[year] = @year
-			AND [area_fips] = '06073'
-			AND [agglvl_code] = 75
-			AND [industry_code] IN ('721', '722')
-	)
-	SELECT
-		[#tt_shell].[ownership_title],
-		[#tt_shell].[naics3],
-		[#tt_shell].[naics_sector],
-		[#tt_shell].[supersector],
-		[#tt_shell].[domain],
-		ISNULL([annual_avg_emplvl], 0) AS [jobs],
-		ISNULL([disclosure_code], '') AS [disclosure_code]
-	FROM [#tt_shell]
-	LEFT OUTER JOIN [qcew]
-		ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
-		AND [#tt_shell].[naics3] = [qcew].[industry_code]
-	ORDER BY
-		[ownership_title],
-		[naics3],
-		[naics_sector],
-		[supersector],
-		[domain]
+    -- Get Annual QCEW totals by ownership and NAICS 3-digit for 721 and 722
+    WITH [qcew] AS (
+        SELECT
+            [ownership_title],
+            [industry_code],
+            [annual_avg_emplvl],
+            [disclosure_code]
+        FROM [socioec_data].[bls].[qcew_by_area_annual]
+        INNER JOIN [socioec_data].[bls].[industry_code]
+            ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
+        INNER JOIN [socioec_data].[bls].[ownership_titles]
+            ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
+        WHERE
+            [year] = @year
+            AND [area_fips] = '06073'  -- San Diego County
+            AND [agglvl_code] = 75  -- Aggregation level 75 (NAICS 3-digit)
+            AND [industry_code] IN ('721', '722')  -- SANDAG only uses 721/722 for NAICS 3-digit
+    )
+    SELECT
+        [#tt_shell].[ownership_title],
+        [#tt_shell].[naics3],
+        [#tt_shell].[naics_sector],
+        [#tt_shell].[supersector],
+        [#tt_shell].[domain],
+        ISNULL([annual_avg_emplvl], 0) AS [jobs],
+        ISNULL([disclosure_code], '') AS [disclosure_code]
+    FROM [#tt_shell]
+    LEFT OUTER JOIN [qcew]
+        ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
+        AND [#tt_shell].[naics3] = [qcew].[industry_code]
+    ORDER BY
+        [ownership_title],
+        [naics3],
+        [naics_sector],
+        [supersector],
+        [domain]
+
+    DROP TABLE IF EXISTS [#tt_shell]
 END

--- a/sql/employment/get_bls_qcew_naics_sector.sql
+++ b/sql/employment/get_bls_qcew_naics_sector.sql
@@ -1,0 +1,73 @@
+/*
+Get BLS QCEW jobs by ownership at aggregation level 74 (NAICS Sector). Ensure
+that all ownerships and naics sectors are represented, filling in 0s where
+appropriate. An indicator of data suppression is returned along with the data.
+*/
+
+SET NOCOUNT ON;
+-- Initialize parameters -----------------------------------------------------
+DECLARE @year integer = :year; 
+DECLARE @msg nvarchar(25) = 'QCEW data does not exist';
+
+-- Send error message if no data exists --------------------------------------
+IF NOT EXISTS (
+    SELECT TOP (1) *
+    FROM [socioec_data].[bls].[qcew_by_area_annual]
+    WHERE [year] = @year
+)
+SELECT @msg AS [msg]
+ELSE
+BEGIN
+	-- Create shell table of all ownership and naics sector combinations
+	DROP TABLE IF EXISTS [#tt_shell]
+	SELECT [ownership_title], [naics_sector], [supersector], [domain]
+	INTO [#tt_shell]
+	FROM (
+		SELECT [ownership_title] FROM (
+			VALUES
+				('Federal Government'),
+				('State Government'),
+				('Local Government'),
+				('Private')
+		) AS [tt1] ([ownership_title])
+	) AS [ownership_title]
+	CROSS JOIN (
+		SELECT DISTINCT [naics_sector], [supersector], [domain]
+		FROM [socioec_data].[bls].[naics_aggregation]
+	) AS [naics_sector];
+
+
+	-- Get Annual QCEW totals by ownership and naics sector
+	WITH [qcew] AS (
+		SELECT
+			[ownership_title],
+			[industry_code],
+			[annual_avg_emplvl],
+			[disclosure_code]
+		FROM [socioec_data].[bls].[qcew_by_area_annual]
+		INNER JOIN [socioec_data].[bls].[industry_code]
+			ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
+		INNER JOIN [socioec_data].[bls].[ownership_titles]
+			ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
+		WHERE
+			[year] = @year
+			AND [area_fips] = '06073'
+			AND [agglvl_code] = 74
+	)
+	SELECT
+		[#tt_shell].[ownership_title],
+		[#tt_shell].[naics_sector],
+		[#tt_shell].[supersector],
+		[#tt_shell].[domain],
+		ISNULL([annual_avg_emplvl], 0) AS [jobs],
+		ISNULL([disclosure_code], '') AS [disclosure_code]
+	FROM [#tt_shell]
+	LEFT OUTER JOIN [qcew]
+		ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
+		AND [#tt_shell].[naics_sector] = [qcew].[industry_code]
+	ORDER BY
+		[ownership_title],
+		[naics_sector],
+		[supersector],
+		[domain]
+END

--- a/sql/employment/get_bls_qcew_naics_sector.sql
+++ b/sql/employment/get_bls_qcew_naics_sector.sql
@@ -18,56 +18,56 @@ IF NOT EXISTS (
 SELECT @msg AS [msg]
 ELSE
 BEGIN
-	-- Create shell table of all ownership and naics sector combinations
-	DROP TABLE IF EXISTS [#tt_shell]
-	SELECT [ownership_title], [naics_sector], [supersector], [domain]
-	INTO [#tt_shell]
-	FROM (
-		SELECT [ownership_title] FROM (
-			VALUES
-				('Federal Government'),
-				('State Government'),
-				('Local Government'),
-				('Private')
-		) AS [tt1] ([ownership_title])
-	) AS [ownership_title]
-	CROSS JOIN (
-		SELECT DISTINCT [naics_sector], [supersector], [domain]
-		FROM [socioec_data].[bls].[naics_aggregation]
-	) AS [naics_sector];
+    -- Create shell table of all ownership and naics sector combinations
+    DROP TABLE IF EXISTS [#tt_shell]
+    SELECT [ownership_title], [naics_sector], [supersector], [domain]
+    INTO [#tt_shell]
+    FROM (
+        VALUES
+            ('Federal Government'),
+            ('State Government'),
+            ('Local Government'),
+            ('Private')
+    ) AS [tt1] ([ownership_title])
+    CROSS JOIN (
+        SELECT DISTINCT [naics_sector], [supersector], [domain]
+        FROM [socioec_data].[bls].[naics_aggregation]
+    ) AS [naics_sector];
 
 
-	-- Get Annual QCEW totals by ownership and naics sector
-	WITH [qcew] AS (
-		SELECT
-			[ownership_title],
-			[industry_code],
-			[annual_avg_emplvl],
-			[disclosure_code]
-		FROM [socioec_data].[bls].[qcew_by_area_annual]
-		INNER JOIN [socioec_data].[bls].[industry_code]
-			ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
-		INNER JOIN [socioec_data].[bls].[ownership_titles]
-			ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
-		WHERE
-			[year] = @year
-			AND [area_fips] = '06073'
-			AND [agglvl_code] = 74
-	)
-	SELECT
-		[#tt_shell].[ownership_title],
-		[#tt_shell].[naics_sector],
-		[#tt_shell].[supersector],
-		[#tt_shell].[domain],
-		ISNULL([annual_avg_emplvl], 0) AS [jobs],
-		ISNULL([disclosure_code], '') AS [disclosure_code]
-	FROM [#tt_shell]
-	LEFT OUTER JOIN [qcew]
-		ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
-		AND [#tt_shell].[naics_sector] = [qcew].[industry_code]
-	ORDER BY
-		[ownership_title],
-		[naics_sector],
-		[supersector],
-		[domain]
+    -- Get Annual QCEW totals by ownership and naics sector
+    WITH [qcew] AS (
+        SELECT
+            [ownership_title],
+            [industry_code],
+            [annual_avg_emplvl],
+            [disclosure_code]
+        FROM [socioec_data].[bls].[qcew_by_area_annual]
+        INNER JOIN [socioec_data].[bls].[industry_code]
+            ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
+        INNER JOIN [socioec_data].[bls].[ownership_titles]
+            ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
+        WHERE
+            [year] = @year
+            AND [area_fips] = '06073'  -- San Diego County
+            AND [agglvl_code] = 74  -- Aggregation level 74 (NAICS Sector)
+    )
+    SELECT
+        [#tt_shell].[ownership_title],
+        [#tt_shell].[naics_sector],
+        [#tt_shell].[supersector],
+        [#tt_shell].[domain],
+        ISNULL([annual_avg_emplvl], 0) AS [jobs],
+        ISNULL([disclosure_code], '') AS [disclosure_code]
+    FROM [#tt_shell]
+    LEFT OUTER JOIN [qcew]
+        ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
+        AND [#tt_shell].[naics_sector] = [qcew].[industry_code]
+    ORDER BY
+        [ownership_title],
+        [naics_sector],
+        [supersector],
+        [domain]
+
+    DROP TABLE IF EXISTS [#tt_shell]
 END

--- a/sql/employment/get_bls_qcew_supersector.sql
+++ b/sql/employment/get_bls_qcew_supersector.sql
@@ -1,0 +1,71 @@
+/*
+Get BLS QCEW jobs by ownership at aggregation level 73 (Supersector). Ensure
+that all ownerships and supersectors are represented, filling in 0s where
+appropriate. An indicator of data suppression is returned along with the data.
+*/
+
+SET NOCOUNT ON;
+-- Initialize parameters -----------------------------------------------------
+DECLARE @year integer = :year; 
+DECLARE @msg nvarchar(25) = 'QCEW data does not exist';
+
+-- Send error message if no data exists --------------------------------------
+IF NOT EXISTS (
+    SELECT TOP (1) *
+    FROM [socioec_data].[bls].[qcew_by_area_annual]
+    WHERE [year] = @year
+)
+SELECT @msg AS [msg]
+ELSE
+BEGIN
+	-- Create shell table of all ownership and supersector combinations
+	DROP TABLE IF EXISTS [#tt_shell]
+	SELECT [ownership_title], [supersector], [domain]
+	INTO [#tt_shell]
+	FROM (
+		SELECT [ownership_title] FROM (
+			VALUES
+				('Federal Government'),
+				('State Government'),
+				('Local Government'),
+				('Private')
+		) AS [tt1] ([ownership_title])
+	) AS [ownership_title]
+	CROSS JOIN (
+		SELECT DISTINCT [supersector], [domain]
+		FROM [socioec_data].[bls].[naics_aggregation]
+	) AS [supersector];
+
+
+	-- Get Annual QCEW totals by ownership and supersector
+	WITH [qcew] AS (
+		SELECT
+			[ownership_title],
+			[industry_code],
+			[annual_avg_emplvl],
+			[disclosure_code]
+		FROM [socioec_data].[bls].[qcew_by_area_annual]
+		INNER JOIN [socioec_data].[bls].[industry_code]
+			ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
+		INNER JOIN [socioec_data].[bls].[ownership_titles]
+			ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
+		WHERE
+			[year] = @year
+			AND [area_fips] = '06073'
+			AND [agglvl_code] = 73
+	)
+	SELECT
+		[#tt_shell].[ownership_title],
+		[#tt_shell].[supersector],
+		[#tt_shell].[domain],
+		ISNULL([annual_avg_emplvl], 0) AS [jobs],
+		ISNULL([disclosure_code], '') AS [disclosure_code]
+	FROM [#tt_shell]
+	LEFT OUTER JOIN [qcew]
+		ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
+		AND [#tt_shell].[supersector] = [qcew].[industry_code]
+	ORDER BY
+		[ownership_title],
+		[supersector],
+		[domain]
+END

--- a/sql/employment/get_bls_qcew_supersector.sql
+++ b/sql/employment/get_bls_qcew_supersector.sql
@@ -18,54 +18,54 @@ IF NOT EXISTS (
 SELECT @msg AS [msg]
 ELSE
 BEGIN
-	-- Create shell table of all ownership and supersector combinations
-	DROP TABLE IF EXISTS [#tt_shell]
-	SELECT [ownership_title], [supersector], [domain]
-	INTO [#tt_shell]
-	FROM (
-		SELECT [ownership_title] FROM (
-			VALUES
-				('Federal Government'),
-				('State Government'),
-				('Local Government'),
-				('Private')
-		) AS [tt1] ([ownership_title])
-	) AS [ownership_title]
-	CROSS JOIN (
-		SELECT DISTINCT [supersector], [domain]
-		FROM [socioec_data].[bls].[naics_aggregation]
-	) AS [supersector];
+    -- Create shell table of all ownership and supersector combinations
+    DROP TABLE IF EXISTS [#tt_shell]
+    SELECT [ownership_title], [supersector], [domain]
+    INTO [#tt_shell]
+    FROM (
+        VALUES
+            ('Federal Government'),
+            ('State Government'),
+            ('Local Government'),
+            ('Private')
+    ) AS [tt1] ([ownership_title])
+    CROSS JOIN (
+        SELECT DISTINCT [supersector], [domain]
+        FROM [socioec_data].[bls].[naics_aggregation]
+    ) AS [supersector];
 
 
-	-- Get Annual QCEW totals by ownership and supersector
-	WITH [qcew] AS (
-		SELECT
-			[ownership_title],
-			[industry_code],
-			[annual_avg_emplvl],
-			[disclosure_code]
-		FROM [socioec_data].[bls].[qcew_by_area_annual]
-		INNER JOIN [socioec_data].[bls].[industry_code]
-			ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
-		INNER JOIN [socioec_data].[bls].[ownership_titles]
-			ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
-		WHERE
-			[year] = @year
-			AND [area_fips] = '06073'
-			AND [agglvl_code] = 73
-	)
-	SELECT
-		[#tt_shell].[ownership_title],
-		[#tt_shell].[supersector],
-		[#tt_shell].[domain],
-		ISNULL([annual_avg_emplvl], 0) AS [jobs],
-		ISNULL([disclosure_code], '') AS [disclosure_code]
-	FROM [#tt_shell]
-	LEFT OUTER JOIN [qcew]
-		ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
-		AND [#tt_shell].[supersector] = [qcew].[industry_code]
-	ORDER BY
-		[ownership_title],
-		[supersector],
-		[domain]
+    -- Get Annual QCEW totals by ownership and supersector
+    WITH [qcew] AS (
+        SELECT
+            [ownership_title],
+            [industry_code],
+            [annual_avg_emplvl],
+            [disclosure_code]
+        FROM [socioec_data].[bls].[qcew_by_area_annual]
+        INNER JOIN [socioec_data].[bls].[industry_code]
+            ON [qcew_by_area_annual].[naics_id] = [industry_code].[naics_id]
+        INNER JOIN [socioec_data].[bls].[ownership_titles]
+            ON [qcew_by_area_annual].[own_code] = [ownership_titles].[ownership_code]
+        WHERE
+            [year] = @year
+            AND [area_fips] = '06073'  -- San Diego County
+            AND [agglvl_code] = 73  -- Aggregation level 73 (Supersector)
+    )
+    SELECT
+        [#tt_shell].[ownership_title],
+        [#tt_shell].[supersector],
+        [#tt_shell].[domain],
+        ISNULL([annual_avg_emplvl], 0) AS [jobs],
+        ISNULL([disclosure_code], '') AS [disclosure_code]
+    FROM [#tt_shell]
+    LEFT OUTER JOIN [qcew]
+        ON [#tt_shell].[ownership_title] = [qcew].[ownership_title]
+        AND [#tt_shell].[supersector] = [qcew].[industry_code]
+    ORDER BY
+        [ownership_title],
+        [supersector],
+        [domain]
+
+    DROP TABLE IF EXISTS [#tt_shell]
 END

--- a/sql/employment/get_military_employment.sql
+++ b/sql/employment/get_military_employment.sql
@@ -38,7 +38,6 @@ BEGIN
         [mgra],
         'Federal Government' AS [ownership_title],
         'MIL' AS [industry_code],
-        'jobs' AS [metric],
         COALESCE(SUM([site_active_duty]), 0) AS [value]
     FROM [GeoDepot].[sde].[MGRA15]
     LEFT OUTER JOIN (

--- a/sql/employment/get_region_edd.sql
+++ b/sql/employment/get_region_edd.sql
@@ -1,0 +1,316 @@
+/*
+Get California Confidential EDD jobs by Ownership and 2-digit NAICS sector.
+Ensure that all ownerships and naics sectors are represented, filling in 0s
+and missing entries with a small constant to ensure scaling to match BLS
+QCEW sums does not fail.
+
+Note this needs to be run on the GIS server as the OPENQUERY string length
+limit is reached running from the Estimates server, the EMPCORE tables contain
+CLR data types, and the Linked Server connection is not set up to use SQL RPC.
+This pattern also moves the most complex queries out of dynamic SQL leaving
+the simplest shell table creation query in dynamic SQL.
+
+There is no EDD point-level data for 2016 in EMPCORE and 2014 data has no
+ownership values. Therefore, both return 'EDD point-level data does not exist'.
+*/
+
+
+SET NOCOUNT ON;
+-- Initialize parameters and return table ------------------------------------
+DECLARE @year INTEGER = :year;
+DECLARE @estimates_server NVARCHAR(20) = :estimates_server;
+DECLARE @msg NVARCHAR(45) = 'EDD point-level data does not exist';
+DECLARE @qry NVARCHAR(MAX)
+
+-- Create shell table of all ownership and naics sector combinations
+DROP TABLE IF EXISTS [#tt_shell];
+CREATE TABLE [#tt_shell] (
+    [ownership_title] NVARCHAR(20) NOT NULL,
+    [naics3] NVARCHAR(3) NULL,
+    [naics_sector] NVARCHAR(5) NOT NULL,
+    [supersector] NVARCHAR(4) NOT NULL,
+    [domain] NVARCHAR(3) NOT NULL,
+    CONSTRAINT [ixuq_tt_shell] UNIQUE ([ownership_title], [naics3], [naics_sector], [supersector], [domain])
+);
+
+SET @qry = '
+    INSERT INTO [#tt_shell]
+    SELECT
+        [ownership_title],
+        [naics3],
+        [naics_sector],
+        [supersector],
+        [domain]
+    FROM (
+	    SELECT [ownership_title] FROM (
+		    VALUES
+			    (''Federal Government''),
+			    (''State Government''),
+			    (''Local Government''),
+			    (''Private'')
+	    ) AS [tt1] ([ownership_title])
+    ) AS [ownership_title]
+    CROSS JOIN (
+	    SELECT *
+	    FROM OPENQUERY([' + @estimates_server + '], ''
+            SELECT DISTINCT [naics_sector], [supersector], [domain]
+            FROM [socioec_data].[bls].[naics_aggregation]
+        '')
+    ) AS [naics_sector]
+    LEFT OUTER JOIN (
+        SELECT [naics3] FROM (
+            VALUES
+                (''721''),
+                (''722'')
+        ) AS [tt2] ([naics3])
+    ) AS [naics3]
+    ON [naics_sector].[naics_sector] = ''72''
+'
+EXECUTE(@qry)
+
+-- Create temporary table for EDD data
+DROP TABLE IF EXISTS [#edd];
+CREATE TABLE [#edd] (
+    [ownership_title] NVARCHAR(20) NOT NULL,
+    [industry_code] NVARCHAR(5) NOT NULL,
+    [jobs] FLOAT NOT NULL,
+    CONSTRAINT [pk_tt_edd] PRIMARY KEY ([ownership_title], [industry_code])
+);
+
+
+-- Get SANDAG GIS team EDD dataset -------------------------------------------
+IF @year >= 2017
+BEGIN
+    INSERT INTO [#edd]
+    SELECT
+        [ownership_title],
+        ISNULL([industry_code], '99') AS [industry_code],
+        SUM(1.0 * [emp_total]/[emp_valid]) AS [jobs]
+    FROM (
+        SELECT
+            CASE
+                WHEN [ownership].[description] = 'Local government' THEN 'Local Government'
+                WHEN [ownership].[description] = 'Federal government' THEN 'Federal Government'
+                WHEN [ownership].[description] = 'Private sector' THEN 'Private'
+                WHEN [ownership].[description] = 'State government' THEN 'State Government'
+                ELSE NULL
+            END AS [ownership_title],
+            CASE
+                WHEN LEFT([naics_code], 2) IN ('31','32','33') THEN '31-33'
+                WHEN LEFT([naics_code], 2) IN ('44','45') THEN '44-45'
+                WHEN LEFT([naics_code], 2) IN ('48','49') THEN '48-49'
+                -- There are records in 2011-2012 tagged as "Self Employed" with [naics_code] = "72"
+                -- There are records in all years with [naics_code] = "999999" as a NULL placeholder
+                WHEN [naics_code] = '72' OR LEFT([naics_code], 2) = '99' THEN NULL
+                WHEN LEFT([naics_code], 2) = '72' THEN LEFT([naics_code], 3)
+                -- NULL records are mapped to NULL despite falling into this ELSE condition
+                -- Keep these records for total EDD jobs xref even if industry code is NULL
+                ELSE LEFT([naics_code], 2)
+            END AS [industry_code],
+            CASE WHEN [emp_m1] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m2] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m3] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m4] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m5] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m6] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m7] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m8] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m9] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m10] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m11] IS NOT NULL THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m12] IS NOT NULL THEN 1 ELSE 0 END 
+            AS [emp_valid],
+            ISNULL([emp_m1], 0) 
+                + ISNULL([emp_m2], 0) 
+                + ISNULL([emp_m3], 0) 
+                + ISNULL([emp_m4], 0) 
+                + ISNULL([emp_m5], 0) 
+                + ISNULL([emp_m6], 0) 
+                + ISNULL([emp_m7], 0) 
+                + ISNULL([emp_m8], 0) 
+                + ISNULL([emp_m9], 0) 
+                + ISNULL([emp_m10], 0) 
+                + ISNULL([emp_m11], 0) 
+                + ISNULL([emp_m12], 0)
+            AS [emp_total]
+        FROM [EMPCORE].[ca_edd].[vi_ca_edd_employment]
+        INNER JOIN [EMPCORE].[ca_edd].[ownership]
+            ON [vi_ca_edd_employment].[ownership_id] = [ownership].[ownership_id]
+        WHERE [year] = @year
+    ) AS [tt]
+    WHERE
+        [emp_valid] > 0
+        AND [emp_total] > 0
+        AND [ownership_title] IN (
+            'Federal Government',
+            'Local Government',
+            'Private',
+            'State Government'
+        )
+    GROUP BY [ownership_title], [industry_code]
+END
+ELSE IF @year BETWEEN 2010 AND 2013
+BEGIN
+    INSERT INTO [#edd]
+    SELECT
+        [ownership_title],
+        ISNULL([industry_code], '99') AS [industry_code],
+        SUM([jobs]) AS [jobs]
+    FROM (
+        SELECT
+            CASE
+                WHEN [ownership].[description] = 'Local government' THEN 'Local Government'
+                WHEN [ownership].[description] = 'Federal government' THEN 'Federal Government'
+                WHEN [ownership].[description] = 'Private sector' THEN 'Private'
+                WHEN [ownership].[description] = 'State government' THEN 'State Government'
+                ELSE NULL
+            END AS [ownership_title],
+            CASE
+                WHEN LEFT([code], 2) IN ('31','32','33') THEN '31-33'
+                WHEN LEFT([code], 2) IN ('44','45') THEN '44-45'
+                WHEN LEFT([code], 2) IN ('48','49') THEN '48-49'
+                -- there are records in 2011-2012 tagged as "Self Employed" with [code] = '72'
+                -- there are records in all years with [code] = '999999' as a NULL placeholder
+                WHEN [code] = '72' OR LEFT([code], 2) = '99' THEN NULL
+                WHEN LEFT([code], 2) = '72' THEN LEFT([code], 3)
+                -- NULL records are mapped to NULL despite falling into this ELSE condition
+                -- Keep these records for total EDD jobs xref even if industry code is NULL
+                ELSE LEFT([code], 2)
+            END AS [industry_code],
+            [employment] * ISNULL([headquarters].[share], 1) AS [jobs]
+        FROM [EMPCORE].[ca_edd].[businesses]
+        LEFT OUTER JOIN [EMPCORE].[ca_edd].[naics]
+            ON [businesses].[naics_id] = [naics].[naics_id]
+        LEFT JOIN [EMPCORE].[ca_edd].[headquarters]
+            ON [businesses].[year] = [headquarters].[year]
+            AND [businesses].[emp_id] = [headquarters].[emp_id]
+        INNER JOIN (
+            SELECT [year], [emp_id], [employment]
+            FROM [EMPCORE].[ca_edd].[employment]
+            WHERE 
+                [month_id] = 14  -- adjusted employment
+                AND [employment] > 0
+                AND [year] = @year
+        ) AS [employment]
+            ON [businesses].[year] = [employment].[year]
+            AND [businesses].[emp_id] = [employment].[emp_id]
+        INNER JOIN [EMPCORE].[ca_edd].[ownership]
+            ON [businesses].[ownership_id] = [ownership].[ownership_id]
+    ) AS [tt]
+    WHERE
+        [jobs] > 0
+        AND [ownership_title] IN (
+            'Federal Government',
+            'Local Government',
+            'Private',
+            'State Government'
+        )
+    GROUP BY [ownership_title], [industry_code]
+END
+ELSE IF @year BETWEEN 2014 AND 2016
+BEGIN
+    INSERT INTO [#edd]
+    SELECT
+        [ownership_title],
+        ISNULL([industry_code], '99') AS [industry_code],
+        SUM([jobs]) AS [jobs]
+    FROM (
+        SELECT
+            CASE
+                WHEN [ownership].[description] = 'Local government' THEN 'Local Government'
+                WHEN [ownership].[description] = 'Federal government' THEN 'Federal Government'
+                WHEN [ownership].[description] = 'Private sector' THEN 'Private'
+                WHEN [ownership].[description] = 'State government' THEN 'State Government'
+                ELSE NULL
+            END AS [ownership_title],
+            CASE
+                WHEN LEFT([code], 2) IN ('31','32','33') THEN '31-33'
+                WHEN LEFT([code], 2) IN ('44','45') THEN '44-45'
+                WHEN LEFT([code], 2) IN ('48','49') THEN '48-49'
+                -- there are records in 2011-2012 tagged as "Self Employed" with [code] = '72'
+                -- there are records in all years with [code] = '999999' as a NULL placeholder
+                WHEN [code] = '72' OR LEFT([code], 2) = '99' THEN NULL
+                WHEN LEFT([code], 2) = '72' THEN LEFT([code], 3)
+                -- NULL records are mapped to NULL despite falling into this ELSE condition
+                -- Keep these records for total EDD jobs xref even if industry code is NULL
+                ELSE LEFT([code], 2)
+            END AS [industry_code],
+            [employment] * ISNULL([headquarters].[share], 1) AS [jobs]
+        FROM [EMPCORE].[ca_edd].[businesses]
+        LEFT OUTER JOIN [EMPCORE].[ca_edd].[naics]
+            ON [businesses].[naics_id] = [naics].[naics_id]
+        LEFT JOIN [EMPCORE].[ca_edd].[headquarters]
+            ON [businesses].[year] = [headquarters].[year]
+            AND [businesses].[emp_id] = [headquarters].[emp_id]
+        INNER JOIN (
+            SELECT
+                [year],
+                [emp_id],
+                -- 15, 16, 17 are mpnths from [employment] table where data was 
+                -- stored in [emp1], [emp2], [emp3] but actual month unknown
+                -- check [EMPCORE].[ca_edd].[month] for more detail
+                1.0 * ((ISNULL([15], 0) + ISNULL([16], 0) + ISNULL([17], 0)) 
+                    /
+                    (CASE WHEN [15] IS NOT NULL THEN 1 ELSE 0 END 
+                        + CASE WHEN [16] IS NOT NULL THEN 1 ELSE 0 END 
+                        + CASE WHEN [17] IS NOT NULL THEN 1 ELSE 0 END
+                    ))
+                AS [employment]
+            FROM [EMPCORE].[ca_edd].[employment]
+            PIVOT(SUM([employment]) FOR [month_id] IN ([15], [16], [17])) AS [pivot]
+            WHERE
+                [year] = @year AND
+                ([15] IS NOT NULL OR [16] IS NOT NULL OR [17] IS NOT NULL)
+        ) AS [employment]
+            ON [businesses].[year] = [employment].[year]
+            AND [businesses].[emp_id] = [employment].[emp_id]
+        INNER JOIN [EMPCORE].[ca_edd].[ownership]
+            ON [businesses].[ownership_id] = [ownership].[ownership_id]
+    ) AS [tt]
+    WHERE
+        [jobs] > 0
+        AND [ownership_title] IN (
+            'Federal Government',
+            'Local Government',
+            'Private',
+            'State Government'
+        )
+    GROUP BY [ownership_title], [industry_code]
+END
+
+
+-- Send error message if no data exists --------------------------------------
+IF NOT EXISTS (
+    SELECT TOP (1) * FROM [#edd]
+)
+SELECT @msg AS [msg]
+ELSE
+BEGIN
+    -- Return EDD data by naics sector with 0s/NULLs filled in ---------------
+    SELECT
+        [#tt_shell].[ownership_title],
+        [#tt_shell].[naics3],
+        [#tt_shell].[naics_sector],
+        [#tt_shell].[supersector],
+        [#tt_shell].[domain],
+        -- Fill in 0-category jobs with default value of 1 divided by the # of records
+        -- To ensure scaling to match suppressed BLS QCEW values does not fail
+        CASE
+            WHEN [jobs] = 0 OR [jobs] IS NULL THEN 1.0/(SELECT COUNT(*) FROM [#tt_shell])
+            ELSE [jobs]
+        END AS [jobs]
+    FROM [#tt_shell]
+    LEFT OUTER JOIN [#edd]
+        ON [#tt_shell].[ownership_title] = [#edd].[ownership_title]
+        AND (
+            ([#tt_shell].[naics_sector] != '72' AND [#tt_shell].[naics_sector] = [#edd].[industry_code])
+            OR ([#tt_shell].[naics_sector] = '72' AND [#tt_shell].[naics3] = [#edd].[industry_code])
+        )
+    ORDER BY
+        [#tt_shell].[ownership_title],
+        [#tt_shell].[naics_sector],
+        [#tt_shell].[naics3]
+END
+
+DROP TABLE IF EXISTS [#tt_shell];
+DROP TABLE IF EXISTS [#edd];

--- a/sql/employment/get_region_edd.sql
+++ b/sql/employment/get_region_edd.sql
@@ -251,7 +251,7 @@ BEGIN
             SELECT
                 [year],
                 [emp_id],
-                -- 15, 16, 17 are mpnths from [employment] table where data was 
+                -- 15, 16, 17 are months from [employment] table where data was
                 -- stored in [emp1], [emp2], [emp3] but actual month unknown
                 -- check [EMPCORE].[ca_edd].[month] for more detail
                 1.0 * ((ISNULL([15], 0) + ISNULL([16], 0) + ISNULL([17], 0)) 

--- a/sql/employment/get_region_edd.sql
+++ b/sql/employment/get_region_edd.sql
@@ -115,18 +115,19 @@ BEGIN
                 -- Keep these records for total EDD jobs xref even if industry code is NULL
                 ELSE LEFT([naics_code], 2)
             END AS [industry_code],
-            CASE WHEN [emp_m1] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m2] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m3] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m4] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m5] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m6] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m7] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m8] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m9] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m10] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m11] IS NOT NULL THEN 1 ELSE 0 END 
-                + CASE WHEN [emp_m12] IS NOT NULL THEN 1 ELSE 0 END 
+            -- Do not consider NULL and 0 records in the dataset
+            CASE WHEN [emp_m1] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m2] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m3] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m4] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m5] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m6] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m7] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m8] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m9] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m10] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m11] > 0 THEN 1 ELSE 0 END 
+                + CASE WHEN [emp_m12] > 0 THEN 1 ELSE 0 END 
             AS [emp_valid],
             ISNULL([emp_m1], 0) 
                 + ISNULL([emp_m2], 0) 

--- a/sql/employment/get_region_edd.sql
+++ b/sql/employment/get_region_edd.sql
@@ -196,6 +196,11 @@ BEGIN
             AND [businesses].[emp_id] = [employment].[emp_id]
         INNER JOIN [EMPCORE].[ca_edd].[ownership]
             ON [businesses].[ownership_id] = [ownership].[ownership_id]
+        -- In 2010 there are 95k "Self Employed" records with [code] = NULL
+        -- Subsequent years assign codes to these records
+        -- They are removed here to avoid an enormous "99" code category
+        -- See https://github.com/SANDAG/BLS/issues/58#issuecomment-5246348671
+        WHERE ([dba] != 'Self Employed' AND [code] IS NOT NULL)
     ) AS [tt]
     WHERE
         [jobs] > 0

--- a/sql/employment/get_region_edd.sql
+++ b/sql/employment/get_region_edd.sql
@@ -12,6 +12,14 @@ the simplest shell table creation query in dynamic SQL.
 
 There is no EDD point-level data for 2016 in EMPCORE and 2014 data has no
 ownership values. Therefore, both return 'EDD point-level data does not exist'.
+
+For 2017 and later, the EDD data is available through a view that allows for
+the calculation of average jobs per month across the year, for the months
+where data is available. For 2010-2013, the "adjusted employment" value is
+used, which is a legacy calculation of unknown origin representing the only
+available employment data for those years. For 2014-2016, the average of three
+months of employment data is used, which we believe may be quarter 3 data, but
+this is not confirmed.
 */
 
 
@@ -93,7 +101,7 @@ BEGIN
                 WHEN [ownership].[description] = 'Federal government' THEN 'Federal Government'
                 WHEN [ownership].[description] = 'Private sector' THEN 'Private'
                 WHEN [ownership].[description] = 'State government' THEN 'State Government'
-                ELSE NULL
+                ELSE NULL  -- filters out "Unknown" ownership records
             END AS [ownership_title],
             CASE
                 WHEN LEFT([naics_code], 2) IN ('31','32','33') THEN '31-33'
@@ -163,7 +171,7 @@ BEGIN
                 WHEN [ownership].[description] = 'Federal government' THEN 'Federal Government'
                 WHEN [ownership].[description] = 'Private sector' THEN 'Private'
                 WHEN [ownership].[description] = 'State government' THEN 'State Government'
-                ELSE NULL
+                ELSE NULL  -- filters out "Unknown" ownership records
             END AS [ownership_title],
             CASE
                 WHEN LEFT([code], 2) IN ('31','32','33') THEN '31-33'
@@ -226,7 +234,7 @@ BEGIN
                 WHEN [ownership].[description] = 'Federal government' THEN 'Federal Government'
                 WHEN [ownership].[description] = 'Private sector' THEN 'Private'
                 WHEN [ownership].[description] = 'State government' THEN 'State Government'
-                ELSE NULL
+                ELSE NULL  -- filters out "Unknown" ownership records
             END AS [ownership_title],
             CASE
                 WHEN LEFT([code], 2) IN ('31','32','33') THEN '31-33'

--- a/sql/employment/get_region_qcew.sql
+++ b/sql/employment/get_region_qcew.sql
@@ -51,7 +51,6 @@ SELECT
     @year AS [year],
     [fn_get_sandag_employment].[ownership_title],
     [fn_get_sandag_employment].[industry_code],
-    'jobs' AS [metric],
     ROUND(SUM([month1_emplvl] + [month2_emplvl] + [month3_emplvl])/12.0, 0) AS [value]
 FROM [socioec_data].[bls].[qcew_by_area_quarterly]
 INNER JOIN [socioec_data].[bls].[industry_code]
@@ -79,7 +78,6 @@ SELECT
     @year AS [year],
     [fn_get_sandag_employment].[ownership_title],
     [fn_get_sandag_employment].[industry_code],
-    'jobs' AS [metric],
     ROUND(SUM([annual_avg_emplvl]), 0) AS [value]
 FROM [socioec_data].[bls].[qcew_by_area_annual]
 INNER JOIN [socioec_data].[bls].[industry_code]

--- a/sql/employment/get_region_qcew.sql
+++ b/sql/employment/get_region_qcew.sql
@@ -35,6 +35,7 @@ created by data suppression.
 
 SET NOCOUNT ON;
 -- Initialize parameters and return table ------------------------------------
+DECLARE @run_id INTEGER = :run_id;
 -- Set year of BLS QCEW data to create SANDAG employment categories
 DECLARE @year INTEGER = :year;
 
@@ -46,6 +47,7 @@ IF @year < 2022 OR @year > 2025
 
 -- Calculate custom SANDAG employment categories using quarterly data --------
 SELECT
+    @run_id AS [run_id],
     @year AS [year],
     [fn_get_sandag_employment].[ownership_title],
     [fn_get_sandag_employment].[industry_code],
@@ -73,6 +75,7 @@ GROUP BY
 
 -- Calculate directly derived employment categories using annual data --------
 SELECT
+    @run_id AS [run_id],
     @year AS [year],
     [fn_get_sandag_employment].[ownership_title],
     [fn_get_sandag_employment].[industry_code],

--- a/wiki/Employment.md
+++ b/wiki/Employment.md
@@ -37,32 +37,32 @@ The [Bureau of Labor Statistics (BLS) Quarterly Census of Employment and Wages (
 
 The SANDAG Economics' Team employment categories are custom-built from a combination of ownership and industry codes. Note the use of industry code "GOV" as the Government ownership categories include all NAICS codes excepting 61, 62, 71, 722, 723. The two-digit NAICS code category of "92" is not provided and is wrapped into the Government ownership categories. The two-digit NAICS code category of "99" is excluded altogether.
 
-ownership_title | industry_code
--- | --
-Private | 11
-Private | 21
-Private | 22
-Private | 23
-Private | 31-33
-Private | 42
-Private | 44-45
-Private | 48-49
-Private | 51
-Private | 52
-Private | 53
-Private | 54
-Private | 55
-Private | 56
-Total Covered | 61
-Total Covered | 62
-Total Covered | 71
-Total Covered | 721
-Total Covered | 722
-Private | 81
-Federal Government | GOV
-Federal Government | MIL
-State Government | GOV
-Local Government | GOV
+| ownership_title  | industry_code |
+|----------------- | ------------- |
+| Private | 11 |
+| Private | 21 |
+| Private | 22 |
+| Private | 23 |
+| Private | 31-33 |
+| Private | 42 |
+| Private | 44-45 |
+| Private | 48-49 |
+| Private | 51 |
+| Private | 52 |
+| Private | 53 |
+| Private | 54 |
+| Private | 55 |
+| Private | 56 |
+| Total Covered | 61 |
+| Total Covered | 62 |
+| Total Covered | 71 |
+| Total Covered | 721 |
+| Total Covered | 722 |
+| Private | 81 |
+| Federal Government | GOV |
+| Federal Government | MIL |
+| State Government | GOV |
+| Local Government | GOV |
 
 
 # Outputs


### PR DESCRIPTION
### Describe this pull request. What changes are being made?
This pull request updates the employment module to correctly use the BLS QCEW to create regional employment controls.

- For 2022-2025, the quarterly data is used for employment categories that cannot be pulled directly from the annual averages
- For 2010-2021, a methodology is used to account for suppression that is present (described in detail in https://github.com/SANDAG/BLS/issues/58)

### Validation and testing
Successful 2020-2025 run in production database as `[run_id]=232` that passed QC checks in `reporting/reporting.py`.

### What issues does this pull request address?
closes #285 
closes https://github.com/SANDAG/BLS/issues/58

### Additional context
Will add a commit to update the Wiki once the methodology is approved here.