### PR TITLE
[PULL REQUEST] Update Wikipedia entry for regional A/S/E controls

### DIFF
--- a/wiki/Regional-Age-Sex-Ethnicity-Controls.md
+++ b/wiki/Regional-Age-Sex-Ethnicity-Controls.md
@@ -18,7 +18,7 @@ Group quarters population is identified as follows:
 | Estimates year(s) | Definition                  |
 |:-----------------:|-----------------------------|
 | 2012-2018         | `[RELP] IN ('16','17')`     |
-| 2016-2024         | `[RELSHIPP] IN ('37','38')` |
+| 2019-2024         | `[RELSHIPP] IN ('37','38')` |
 *Note: Estimates years 2010-2011 use the 2008-2012 ACS PUMS corresponding to estimates year 2012*
 
 Further filtering is done to identify specific GQ types:

--- a/wiki/Regional-Age-Sex-Ethnicity-Controls.md
+++ b/wiki/Regional-Age-Sex-Ethnicity-Controls.md
@@ -10,40 +10,30 @@
 See [Population by Type](https://github.com/SANDAG/Estimates-Program/wiki/Population-by-Type).
 
 ## Regional age/sex/ethnicity distributions for group quarters by type
-The regional age/sex/ethnicity distributions for group quarters by type are calculated using the 5-year American Community Survey (ACS) Public Use Microdata Sample (PUMS) for the given estimates year (e.g., 2020 uses the 2016-2020 PUMS, 2021 the 2017-2021 PUMS, ...). For documentation, including field definitions, see the [PUMS Documentation](https://www.census.gov/programs-surveys/acs/microdata/documentation.html).
+The regional age/sex/ethnicity distributions for group quarters by type are calculated using the 5-year American Community Survey (ACS) Public Use Microdata Sample (PUMS) for the given estimates year (e.g., 2020 uses the 2016-2020 PUMS, 2021 the 2017-2021 PUMS, ...) excepting for years 2010 and 2011 which use the 2008-2012 PUMS (due to the lack of `[DIS]` field used to identify Institutional Correctional Facilities). For detailed documentation of the ACS PUMS, including field definitions, see the [PUMS Documentation](https://www.census.gov/programs-surveys/acs/microdata/documentation.html).
 
 Age/sex/ethnicity is encoded using the fields `[AGEP]`, `[SEX]`, `[HISP]`, and `[RAC1P]`.
 
 Group quarters population is identified as follows:
 | Estimates year(s) | Definition                  |
 |:-----------------:|-----------------------------|
-| 2010              | `[RELP] IN ('14','15')`     |
-| 2011              | `[RELP] IN ('13','14')`     |
 | 2012-2018         | `[RELP] IN ('16','17')`     |
-| 2016-2023         | `[RELSHIPP] IN ('37','38')` |
+| 2016-2024         | `[RELSHIPP] IN ('37','38')` |
+*Note: Estimates years 2010-2011 use the 2008-2012 ACS PUMS corresponding to estimates year 2012*
 
 Further filtering is done to identify specific GQ types:
 | Estimates year(s) | Group Quarters Type                   | Definition                                           |
 | :----------------:|---------------------------------------|------------------------------------------------------|
-| 2010              | College                               | `[SCHG] IN ('6', '7')`                               |
-|                   | Military                              | `[ESR] IN ('4','5')`                                 |
-|                   | Institutional Correctional Facilities | `[RELP] = '14' AND [AGEP] >= 10`                     |
-|                   | Other                                 | all other group quarters persons                     |
-|                   |                                       |                                                      |
-| 2011              | College                               | `[SCHG] IN ('6', '7')`                               |
-|                   | Military                              | `[ESR] IN ('4','5')`                                 |
-|                   | Institutional Correctional Facilities | `[RELP] = '13' AND [AGEP] >= 10`                     |
-|                   | Other                                 | all other group quarters persons                     |
-|                   |                                       |                                                      |
 | 2012-2018         | College                               | `[SCHG] IN ('15', '16')`                             |
 |                   | Military                              | `[ESR] IN ('4','5')`                                 |
 |                   | Institutional Correctional Facilities | `[RELP] = '16' AND [DIS] = '2' AND [AGEP] >= 10`     |
 |                   | Other                                 | all other group quarters persons                     |
 |                   |                                       |                                                      |
-| 2019-2023         | College                               | `[SCHG] IN ('15', '16')`                             |
+| 2019-2024         | College                               | `[SCHG] IN ('15', '16')`                             |
 |                   | Military                              | `[ESR] IN ('4','5')`                                 |
 |                   | Institutional Correctional Facilities | `[RELSHIPP] = '37' AND [DIS] = '2' AND [AGEP] >= 10` |
 |                   | Other                                 | all other group quarters persons                     |
+*Note: Estimates years 2010-2011 use the 2008-2012 ACS PUMS corresponding to estimates year 2012*
 
 ## Regional age/sex/ethnicity controls for total population
 The regional age/sex/ethnicity controls for total population are derived from the most recent [California Department of Finance (DOF) Projections](https://dof.ca.gov/forecasting/demographics/projections/) P-3 product available at the time. 

--- a/wiki/Regional-Age-Sex-Ethnicity-Controls.md
+++ b/wiki/Regional-Age-Sex-Ethnicity-Controls.md
@@ -10,7 +10,7 @@
 See [Population by Type](https://github.com/SANDAG/Estimates-Program/wiki/Population-by-Type).
 
 ## Regional age/sex/ethnicity distributions for group quarters by type
-The regional age/sex/ethnicity distributions for group quarters by type are calculated using the 5-year American Community Survey (ACS) Public Use Microdata Sample (PUMS) for the given estimates year (e.g., 2020 uses the 2016-2020 PUMS, 2021 the 2017-2021 PUMS, ...) excepting for years 2010 and 2011 which use the 2008-2012 PUMS (due to the lack of `[DIS]` field used to identify Institutional Correctional Facilities). For detailed documentation of the ACS PUMS, including field definitions, see the [PUMS Documentation](https://www.census.gov/programs-surveys/acs/microdata/documentation.html).
+The regional age/sex/ethnicity distributions for group quarters by type are calculated using the 5-year American Community Survey (ACS) Public Use Microdata Sample (PUMS) for the given estimates year (e.g., 2020 uses the 2016-2020 PUMS, 2021 the 2017-2021 PUMS, ...) except for years 2010 and 2011, which use the 2008-2012 PUMS (due to the lack of the `[DIS]` field used to identify Institutional Correctional Facilities). For detailed documentation of the ACS PUMS, including field definitions, see the [PUMS Documentation](https://www.census.gov/programs-surveys/acs/microdata/documentation.html).
 
 Age/sex/ethnicity is encoded using the fields `[AGEP]`, `[SEX]`, `[HISP]`, and `[RAC1P]`.
 


### PR DESCRIPTION
### Describe this pull request. What changes are being made?
The current Wikipedia page https://github.com/SANDAG/Estimates-Program/wiki/Regional-Age-Sex-Ethnicity-Controls section on "Regional age/sex/ethnicity distributions for group quarters by type" does not accurately reflect changes that have been made to `sql/ase/get_region_gq_ase_dist.sql` in #201 and #203.

### Validation and testing
Previewed the Wikipedia page.

### What issues does this pull request address?
closes #293

### Additional context
This was noticed when looking into a data@sandag.org request for more information on age/sex/ethnicity.
